### PR TITLE
SAR domain generalization initial work

### DIFF
--- a/jobs/JFV3CAM_NEST_ENVIR
+++ b/jobs/JFV3CAM_NEST_ENVIR
@@ -16,7 +16,7 @@ export CRES=768          #-- FV3 equivalent to 13-km global resolution
 export CASE=C${CRES}
 export gtype=nest        # grid type = uniform, stretch, nest, or regional
 
-export HOMEfv3=/gpfs/dell2/emc/modeling/noscrub/$USER/fv3cam_workflow
+export HOMEfv3=/gpfs/dell2/emc/modeling/noscrub/$USER/regional_workflow
 export PARMfv3=$HOMEfv3/parm
 export EXECfv3=$HOMEfv3/exec
 export USHfv3=$HOMEfv3/ush

--- a/jobs/JFV3CAM_SAR_CHGRES_FCSTBNDY
+++ b/jobs/JFV3CAM_SAR_CHGRES_FCSTBNDY
@@ -53,7 +53,7 @@ mkdir -p $COMOUT
 export NWGES=${COMROOT}/${NET}/${envir}/${RUN}.${PDY}/${cyc}
 mkdir -p $NWGES
 
-export INPdir=${COMOUT}/anl.${tmmark}
+export INPdir=${COMOUT}/anl.${dom}.${tmmark}
 mkdir -p ${INPdir}
 
 #####################################

--- a/jobs/JFV3CAM_SAR_CHGRES_FIRSTGUESS
+++ b/jobs/JFV3CAM_SAR_CHGRES_FIRSTGUESS
@@ -53,7 +53,7 @@ mkdir -p $NWGES
 if [ $tmmark = tm12 ] ; then	# SAR-DA
   export INPdir=$COMOUT/gfsanl.$tmmark
 elif [ $tmmark = tm00 ] ; then	# SAR without DA
-  export INPdir=$COMOUT/anl.$tmmark
+  export INPdir=$COMOUT/anl.${dom}.$tmmark
 fi
 mkdir -p $INPdir
 

--- a/jobs/JFV3CAM_SAR_ENVIR
+++ b/jobs/JFV3CAM_SAR_ENVIR
@@ -16,13 +16,13 @@ export CRES=768          #-- FV3 equivalent to 13-km global resolution
 export CASE=C${CRES}
 export gtype=regional    # grid type = uniform, stretch, nest, or regional
 
-export HOMEfv3=/gpfs/dell2/emc/modeling/noscrub/$USER/fv3cam_workflow
+export HOMEfv3=/gpfs/dell2/emc/modeling/noscrub/$USER/regional_workflow
 export PARMfv3=$HOMEfv3/parm
 export EXECfv3=$HOMEfv3/exec
 export USHfv3=$HOMEfv3/ush
 
 export FIXfv3=$HOMEfv3/fix
-export FIXsar=$FIXfv3/fix_sar
+export FIXsar=$FIXfv3/fix_sar/${dom}
 export FIXam=$FIXfv3/fix_am
 export FIXco2=$FIXam/fix_co2_proj
 

--- a/jobs/JFV3CAM_SAR_FCST
+++ b/jobs/JFV3CAM_SAR_FCST
@@ -61,7 +61,7 @@ export CYCfcst=`echo $CYCLEfcst | cut -c 9-10`
 
 export GUESSdir=$COMOUT/guess.${tmmark_next}
 mkdir -p $GUESSdir
-export ANLdir=$COMOUT/anl.${tmmark_next}
+export ANLdir=$COMOUT/anl.${dom}.${tmmark_next}
 mkdir -p $ANLdir
 
 #####################################

--- a/jobs/JFV3CAM_SAR_POST
+++ b/jobs/JFV3CAM_SAR_POST
@@ -26,7 +26,7 @@ export WGRIB2=${EXECfv3}/wgrib2new
 #####################################
 # Working directories
 #####################################
-export INPUT_DATA=${INPUT_DATA:-${mainroot}/${tmpdir}/${USER}/tmpnwprd/forecast_${tmmark}_${PDY}_${cyc}}
+export INPUT_DATA=${INPUT_DATA:-${mainroot}/${tmpdir}/${USER}/tmpnwprd/forecast_${tmmark}_${dom}_${PDY}_${cyc}}
 export DATA=${DATA:-${mainroot}/${tmpdir}/${USER}/tmpnwprd/${job}_${cyc}}
 if [ -d $DATA ]; then
   rm -rf $DATA

--- a/jobs/JFV3CAM_SAR_POST_GOES
+++ b/jobs/JFV3CAM_SAR_POST_GOES
@@ -26,7 +26,7 @@ export WGRIB2=${EXECfv3}/wgrib2new
 #####################################
 # Working directories
 #####################################
-export INPUT_DATA=${INPUT_DATA:-${mainroot}/${tmpdir}/${USER}/tmpnwprd/forecast_${tmmark}_${PDY}_${cyc}}
+export INPUT_DATA=${INPUT_DATA:-${mainroot}/${tmpdir}/${USER}/tmpnwprd/forecast_${tmmark}_${dom}_${PDY}_${cyc}}
 export DATA=${DATA:-${mainroot}/${tmpdir}/${USER}/tmpnwprd/${job}_${cyc}}
 if [ -d $DATA ]; then
   rm -rf $DATA

--- a/jobs/JFV3CAM_SAR_SENDINIBC
+++ b/jobs/JFV3CAM_SAR_SENDINIBC
@@ -3,7 +3,7 @@ set -x
 
 . $HOMEfv3/jobs/JFV3CAM_SAR_ENVIR
 
-export DATA=${mainroot}/${comdir}/${USER}/com/${NET}/${envir}/${RUN}.${PDY}/${cyc}/anl.tm00
+export DATA=${mainroot}/${comdir}/${USER}/com/${NET}/${envir}/${RUN}.${PDY}/${cyc}/anl.${dom}.tm00
 cd $DATA
 
 export pid=$$

--- a/parm/input_sar_ak.nml
+++ b/parm/input_sar_ak.nml
@@ -1,0 +1,284 @@
+ &amip_interp_nml
+     interp_oi_sst = .true.
+     use_ncep_sst = .true.
+     use_ncep_ice = .false.
+     no_anom_sst = .false.
+     data_set = 'reynolds_oi',
+     date_out_of_range = 'climo',
+/
+
+ &atmos_model_nml
+     blocksize = 24
+     chksum_debug = .false.
+     dycore_only = .false.
+     fdiag = 1
+     avg_max_length = 3600.
+/
+
+&diag_manager_nml
+      prepend_date = .false.
+/
+
+ &fms_io_nml
+       checksum_required   = .false.
+       max_files_r = 100,
+       max_files_w = 100,
+/
+
+ &fms_nml
+       clock_grain = 'ROUTINE',
+       domains_stack_size = 1800200,
+       print_memory_usage = .false.
+/
+
+ &fv_grid_nml
+       grid_file = 'INPUT/grid_spec.nc'
+/
+
+ &fv_core_nml
+       layout   = 16,48
+       io_layout = 1,1
+       npx      = 1345
+       npy      = 1153
+       ntiles   = 1,
+       npz    = 64
+!       grid_type = -1
+       make_nh = .T.
+       fv_debug = .F.
+       range_warn = .F.
+       reset_eta = .F.
+       n_sponge = 24
+       nudge_qv = .F.
+       tau = 5.
+       rf_cutoff = 20.e2
+       d2_bg_k1 = 0.20
+       d2_bg_k2 = 0.04
+       kord_tm = -11
+       kord_mt =  11
+       kord_wz =  11
+       kord_tr =  11
+       hydrostatic = .F.
+       phys_hydrostatic = .F.
+       use_hydro_pressure = .F.
+       beta = 0.
+       a_imp = 1.
+       p_fac = 0.1
+       k_split  = 6
+       n_split  = 6
+       nwat = 6
+       na_init = 1
+       d_ext = 0.0
+       dnats = 1
+       fv_sg_adj = 300
+       d2_bg = 0.
+       nord =  2
+       dddmp = 0.1
+       d4_bg = 0.15
+       vtdm4 = 0.075
+       delt_max = 0.008
+       ke_bg = 0.
+       do_vort_damp = .true.
+       external_ic = .T.
+       external_eta = .T.
+       gfs_phil = .false.
+       nggps_ic = .T.
+       mountain = .F.
+       ncep_ic = .F.
+       d_con = 1.0
+       hord_mt = 6
+       hord_vt = 6
+       hord_tm = 6
+       hord_dp = -6
+       hord_tr = 8
+       adjust_dry_mass = .F.
+       consv_te = 0.
+       do_sat_adj = .T.
+       consv_am = .F.
+       fill = .T.
+       dwind_2d = .F.
+       print_freq = 6
+       warm_start = .F.
+       no_dycore = .false.
+       z_tracer = .T.
+       read_increment = .F.
+       res_latlon_dynamics = "fv3_increment.nc"
+
+       do_schmidt = .true.
+       target_lat = 61.0
+       target_lon = -153.0
+       stretch_fac = 1.5
+       regional = .true.
+       bc_update_interval = 3
+       agrid_vel_rst = .false.
+
+       full_zs_filter = .F. !unreleased feature
+
+       nord_zs_filter = 4
+       n_zs_filter = 0 ! safety
+/
+
+&surf_map_nml
+    zero_ocean = .F.
+    cd4 = 0.12
+    cd2 = -1
+    n_del2_strong = 0
+    n_del2_weak = 2
+    n_del4 = 1
+    max_slope = 0.4
+    peak_fac = 1.
+/
+
+ &external_ic_nml 
+       filtered_terrain = .true.
+       levp = 65
+       gfs_dwinds = .true.
+       checker_tr = .F.
+       nt_checker = 0
+/
+
+ &gfs_physics_nml
+       fhzero         = 1.
+       ldiag3d        = .false.
+       lradar         = .true.
+       avg_max_length = 3600.
+       h2o_phys       = .true.
+       fhcyc          = 24.
+       nst_anl        = .true.
+       use_ufo        = .true.
+       pre_rad        = .false.
+       ncld           = 5
+       imp_physics    = 11
+       pdfcld         = .false.
+       fhswr          = 3600.
+       fhlwr          = 3600.
+       ialb           = 1
+       iems           = 1
+       IAER           = 111
+       ico2           = 2
+       isubc_sw       = 2
+       isubc_lw       = 2
+       isol           = 2
+       lwhtr          = .true.
+       swhtr          = .true.
+       cnvgwd         = .false.
+       cal_pre        = .false.
+       redrag         = .true.
+       dspheat        = .true.
+       hybedmf        = .true.
+       random_clds    = .false.
+       trans_trac     = .true.
+       cnvcld         = .false.
+       imfshalcnv     = 2
+       imfdeepcnv     = 2
+       cdmbgwd        = 3.5, 0.01       ! NCEP default
+       prslrd0        = 0.
+       ivegsrc        = 1
+       isot           = 1
+       debug          = .false.
+       nstf_name      = 2,0,0,0,0
+       iau_delthrs    = 6
+       iaufhrs        = 30
+       iau_inc_files  = ''
+       shal_cnv = .false. !Shallow convection
+       do_deep = .false.
+       lgfdlmprad = .true.
+       effr_in = .true.
+/
+
+ &gfdl_cloud_microphysics_nml
+       sedi_transport = .false.
+       do_sedi_heat = .false.
+       rad_snow = .true.
+       rad_graupel = .true.
+       rad_rain = .true.
+       const_vi = .F.
+       const_vs = .F.
+       const_vg = .F.
+       const_vr = .F.
+       vi_max = 1.
+       vs_max = 2.
+       vg_max = 12.
+       vr_max = 12.
+       qi_lim = 1.
+       prog_ccn = .false.
+       do_qa = .true.
+       fast_sat_adj = .true.
+       tau_l2v = 180.
+       tau_v2l = 90.
+       tau_g2v = 900.
+       rthresh = 10.e-6  ! This is a key parameter for cloud water
+       dw_land  = 0.16
+       dw_ocean = 0.10
+       ql_gen = 1.0e-3
+       ql_mlt = 1.0e-3
+       qi0_crt = 8.0E-5
+       qs0_crt = 1.0e-3
+       tau_i2s = 1000.
+       c_psaci = 0.05
+       c_pgacs = 0.01
+       rh_inc = 0.30
+       rh_inr = 0.30
+       rh_ins = 0.30
+       ccn_l = 300.
+       ccn_o = 100.
+       c_paut = 0.5
+       c_cracw = 0.8
+       use_ppm = .false.
+       use_ccn = .true.
+       mono_prof = .true.
+       z_slope_liq  = .true.
+       z_slope_ice  = .true.
+       de_ice = .false.
+       fix_negative = .true.
+       icloud_f = 1
+       mp_time = 90.
+/
+  &interpolator_nml
+       interp_method = 'conserve_great_circle'
+/
+
+&namsfc
+       FNALBC2  = "C768.facsf.tileX.nc",
+       FNALBC   = "C768.snowfree_albedo.tileX.nc",
+       FNTG3C   = "C768.substrate_temperature.tileX.nc",
+       FNVEGC   = "C768.vegetation_greenness.tileX.nc",
+       FNVETC   = "C768.vegetation_type.tileX.nc",
+       FNSOTC   = "C768.soil_type.tileX.nc",
+       FNVMNC   = "C768.vegetation_greenness.tileX.nc",
+       FNVMXC   = "C768.vegetation_greenness.tileX.nc",
+       FNSLPC   = "C768.slope_type.tileX.nc",
+       FNABSC   = "C768.maximum_snow_albedo.tileX.nc",
+       FNGLAC   = "global_glacier.2x2.grb",
+       FNMXIC   = "global_maxice.2x2.grb",
+       FNTSFC   = "RTGSST.1982.2012.monthly.clim.grb",
+       FNSNOC   = "global_snoclim.1.875.grb",
+       FNZORC   = "igbp"
+       FNAISC   = "CFSR.SEAICE.1982.2012.monthly.clim.grb",
+       FNSMCC   = "global_soilmgldas.t1534.3072.1536.grb",
+       FNMSKH   = "seaice_newland.grb",
+       FNTSFA   = "",
+       FNACNA   = "",
+       FNSNOA   = "",
+       LDEBUG   =.true.,
+       FSMCL(2) = 99999
+       FSMCL(3) = 99999
+       FSMCL(4) = 99999
+       FTSFS    = 90
+       FAISS    = 99999
+       FSNOL    = 99999
+       FSICL    = 99999
+       FTSFL    = 99999,
+       FAISL    = 99999,
+       FVETL    = 99999,
+       FSOTL    = 99999,
+       FvmnL    = 99999,
+       FvmxL    = 99999,
+       FSLPL    = 99999,
+       FABSL    = 99999,
+       FSNOS    = 99999,
+       FSICS    = 99999,
+/
+&nam_stochy
+/
+&nam_sfcperts
+/

--- a/parm/input_sar_conus.nml
+++ b/parm/input_sar_conus.nml
@@ -1,0 +1,284 @@
+ &amip_interp_nml
+     interp_oi_sst = .true.
+     use_ncep_sst = .true.
+     use_ncep_ice = .false.
+     no_anom_sst = .false.
+     data_set = 'reynolds_oi',
+     date_out_of_range = 'climo',
+/
+
+ &atmos_model_nml
+     blocksize = 24
+     chksum_debug = .false.
+     dycore_only = .false.
+     fdiag = 1
+     avg_max_length = 3600.
+/
+
+&diag_manager_nml
+      prepend_date = .false.
+/
+
+ &fms_io_nml
+       checksum_required   = .false.
+       max_files_r = 100,
+       max_files_w = 100,
+/
+
+ &fms_nml
+       clock_grain = 'ROUTINE',
+       domains_stack_size = 1800200,
+       print_memory_usage = .false.
+/
+
+ &fv_grid_nml
+       grid_file = 'INPUT/grid_spec.nc'
+/
+
+ &fv_core_nml
+       layout   = 16,72
+       io_layout = 1,1
+       npx      = 1921
+       npy      = 1297
+       ntiles   = 1,
+       npz    = 64
+!       grid_type = -1
+       make_nh = .T.
+       fv_debug = .F.
+       range_warn = .F.
+       reset_eta = .F.
+       n_sponge = 24
+       nudge_qv = .F.
+       tau = 5.
+       rf_cutoff = 20.e2
+       d2_bg_k1 = 0.20
+       d2_bg_k2 = 0.04
+       kord_tm = -11
+       kord_mt =  11
+       kord_wz =  11
+       kord_tr =  11
+       hydrostatic = .F.
+       phys_hydrostatic = .F.
+       use_hydro_pressure = .F.
+       beta = 0.
+       a_imp = 1.
+       p_fac = 0.1
+       k_split  = 6
+       n_split  = 6
+       nwat = 6
+       na_init = 1
+       d_ext = 0.0
+       dnats = 1
+       fv_sg_adj = 300
+       d2_bg = 0.
+       nord =  2
+       dddmp = 0.1
+       d4_bg = 0.15
+       vtdm4 = 0.075
+       delt_max = 0.008
+       ke_bg = 0.
+       do_vort_damp = .true.
+       external_ic = .T.
+       external_eta = .T.
+       gfs_phil = .false.
+       nggps_ic = .T.
+       mountain = .F.
+       ncep_ic = .F.
+       d_con = 1.0
+       hord_mt = 6
+       hord_vt = 6
+       hord_tm = 6
+       hord_dp = -6
+       hord_tr = 8
+       adjust_dry_mass = .F.
+       consv_te = 0.
+       do_sat_adj = .T.
+       consv_am = .F.
+       fill = .T.
+       dwind_2d = .F.
+       print_freq = 6
+       warm_start = .F.
+       no_dycore = .false.
+       z_tracer = .T.
+       read_increment = .F.
+       res_latlon_dynamics = "fv3_increment.nc"
+
+       do_schmidt = .true.
+       target_lat = 38.5
+       target_lon = -97.5
+       stretch_fac = 1.5
+       regional = .true.
+       bc_update_interval = 3
+       agrid_vel_rst = .false.
+
+       full_zs_filter = .F. !unreleased feature
+
+       nord_zs_filter = 4
+       n_zs_filter = 0 ! safety
+/
+
+&surf_map_nml
+    zero_ocean = .F.
+    cd4 = 0.12
+    cd2 = -1
+    n_del2_strong = 0
+    n_del2_weak = 2
+    n_del4 = 1
+    max_slope = 0.4
+    peak_fac = 1.
+/
+
+ &external_ic_nml 
+       filtered_terrain = .true.
+       levp = 65
+       gfs_dwinds = .true.
+       checker_tr = .F.
+       nt_checker = 0
+/
+
+ &gfs_physics_nml
+       fhzero         = 1.
+       ldiag3d        = .false.
+       lradar         = .true.
+       avg_max_length = 3600.
+       h2o_phys       = .true.
+       fhcyc          = 24.
+       nst_anl        = .true.
+       use_ufo        = .true.
+       pre_rad        = .false.
+       ncld           = 5
+       imp_physics    = 11
+       pdfcld         = .false.
+       fhswr          = 3600.
+       fhlwr          = 3600.
+       ialb           = 1
+       iems           = 1
+       IAER           = 111
+       ico2           = 2
+       isubc_sw       = 2
+       isubc_lw       = 2
+       isol           = 2
+       lwhtr          = .true.
+       swhtr          = .true.
+       cnvgwd         = .false.
+       cal_pre        = .false.
+       redrag         = .true.
+       dspheat        = .true.
+       hybedmf        = .true.
+       random_clds    = .false.
+       trans_trac     = .true.
+       cnvcld         = .false.
+       imfshalcnv     = 2
+       imfdeepcnv     = 2
+       cdmbgwd        = 3.5, 0.01       ! NCEP default
+       prslrd0        = 0.
+       ivegsrc        = 1
+       isot           = 1
+       debug          = .false.
+       nstf_name      = 2,0,0,0,0
+       iau_delthrs    = 6
+       iaufhrs        = 30
+       iau_inc_files  = ''
+       shal_cnv = .false. !Shallow convection
+       do_deep = .false.
+       lgfdlmprad = .true.
+       effr_in = .true.
+/
+
+ &gfdl_cloud_microphysics_nml
+       sedi_transport = .false.
+       do_sedi_heat = .false.
+       rad_snow = .true.
+       rad_graupel = .true.
+       rad_rain = .true.
+       const_vi = .F.
+       const_vs = .F.
+       const_vg = .F.
+       const_vr = .F.
+       vi_max = 1.
+       vs_max = 2.
+       vg_max = 12.
+       vr_max = 12.
+       qi_lim = 1.
+       prog_ccn = .false.
+       do_qa = .true.
+       fast_sat_adj = .true.
+       tau_l2v = 180.
+       tau_v2l = 90.
+       tau_g2v = 900.
+       rthresh = 10.e-6  ! This is a key parameter for cloud water
+       dw_land  = 0.16
+       dw_ocean = 0.10
+       ql_gen = 1.0e-3
+       ql_mlt = 1.0e-3
+       qi0_crt = 8.0E-5
+       qs0_crt = 1.0e-3
+       tau_i2s = 1000.
+       c_psaci = 0.05
+       c_pgacs = 0.01
+       rh_inc = 0.30
+       rh_inr = 0.30
+       rh_ins = 0.30
+       ccn_l = 300.
+       ccn_o = 100.
+       c_paut = 0.5
+       c_cracw = 0.8
+       use_ppm = .false.
+       use_ccn = .true.
+       mono_prof = .true.
+       z_slope_liq  = .true.
+       z_slope_ice  = .true.
+       de_ice = .false.
+       fix_negative = .true.
+       icloud_f = 1
+       mp_time = 90.
+/
+  &interpolator_nml
+       interp_method = 'conserve_great_circle'
+/
+
+&namsfc
+       FNALBC2  = "C768.facsf.tileX.nc",
+       FNALBC   = "C768.snowfree_albedo.tileX.nc",
+       FNTG3C   = "C768.substrate_temperature.tileX.nc",
+       FNVEGC   = "C768.vegetation_greenness.tileX.nc",
+       FNVETC   = "C768.vegetation_type.tileX.nc",
+       FNSOTC   = "C768.soil_type.tileX.nc",
+       FNVMNC   = "C768.vegetation_greenness.tileX.nc",
+       FNVMXC   = "C768.vegetation_greenness.tileX.nc",
+       FNSLPC   = "C768.slope_type.tileX.nc",
+       FNABSC   = "C768.maximum_snow_albedo.tileX.nc",
+       FNGLAC   = "global_glacier.2x2.grb",
+       FNMXIC   = "global_maxice.2x2.grb",
+       FNTSFC   = "RTGSST.1982.2012.monthly.clim.grb",
+       FNSNOC   = "global_snoclim.1.875.grb",
+       FNZORC   = "igbp"
+       FNAISC   = "CFSR.SEAICE.1982.2012.monthly.clim.grb",
+       FNSMCC   = "global_soilmgldas.t1534.3072.1536.grb",
+       FNMSKH   = "seaice_newland.grb",
+       FNTSFA   = "",
+       FNACNA   = "",
+       FNSNOA   = "",
+       LDEBUG   =.true.,
+       FSMCL(2) = 99999
+       FSMCL(3) = 99999
+       FSMCL(4) = 99999
+       FTSFS    = 90
+       FAISS    = 99999
+       FSNOL    = 99999
+       FSICL    = 99999
+       FTSFL    = 99999,
+       FAISL    = 99999,
+       FVETL    = 99999,
+       FSOTL    = 99999,
+       FvmnL    = 99999,
+       FvmxL    = 99999,
+       FSLPL    = 99999,
+       FABSL    = 99999,
+       FSNOS    = 99999,
+       FSICS    = 99999,
+/
+&nam_stochy
+/
+&nam_sfcperts
+/

--- a/parm/input_sar_conus.nml
+++ b/parm/input_sar_conus.nml
@@ -36,7 +36,7 @@
 /
 
  &fv_core_nml
-       layout   = 16,72
+       layout   = 16,48
        io_layout = 1,1
        npx      = 1921
        npy      = 1297

--- a/parm/input_sar_guam.nml
+++ b/parm/input_sar_guam.nml
@@ -1,0 +1,284 @@
+ &amip_interp_nml
+     interp_oi_sst = .true.
+     use_ncep_sst = .true.
+     use_ncep_ice = .false.
+     no_anom_sst = .false.
+     data_set = 'reynolds_oi',
+     date_out_of_range = 'climo',
+/
+
+ &atmos_model_nml
+     blocksize = 24
+     chksum_debug = .false.
+     dycore_only = .false.
+     fdiag = 1
+     avg_max_length = 3600.
+/
+
+&diag_manager_nml
+      prepend_date = .false.
+/
+
+ &fms_io_nml
+       checksum_required   = .false.
+       max_files_r = 100,
+       max_files_w = 100,
+/
+
+ &fms_nml
+       clock_grain = 'ROUTINE',
+       domains_stack_size = 1800200,
+       print_memory_usage = .false.
+/
+
+ &fv_grid_nml
+       grid_file = 'INPUT/grid_spec.nc'
+/
+
+ &fv_core_nml
+       layout   = 6,12
+       io_layout = 1,1
+       npx      = 433
+       npy      = 361
+       ntiles   = 1,
+       npz    = 64
+!       grid_type = -1
+       make_nh = .T.
+       fv_debug = .F.
+       range_warn = .F.
+       reset_eta = .F.
+       n_sponge = 24
+       nudge_qv = .F.
+       tau = 5.
+       rf_cutoff = 20.e2
+       d2_bg_k1 = 0.20
+       d2_bg_k2 = 0.04
+       kord_tm = -11
+       kord_mt =  11
+       kord_wz =  11
+       kord_tr =  11
+       hydrostatic = .F.
+       phys_hydrostatic = .F.
+       use_hydro_pressure = .F.
+       beta = 0.
+       a_imp = 1.
+       p_fac = 0.1
+       k_split  = 6
+       n_split  = 6
+       nwat = 6
+       na_init = 1
+       d_ext = 0.0
+       dnats = 1
+       fv_sg_adj = 300
+       d2_bg = 0.
+       nord =  2
+       dddmp = 0.1
+       d4_bg = 0.15
+       vtdm4 = 0.075
+       delt_max = 0.008
+       ke_bg = 0.
+       do_vort_damp = .true.
+       external_ic = .T.
+       external_eta = .T.
+       gfs_phil = .false.
+       nggps_ic = .T.
+       mountain = .F.
+       ncep_ic = .F.
+       d_con = 1.0
+       hord_mt = 6
+       hord_vt = 6
+       hord_tm = 6
+       hord_dp = -6
+       hord_tr = 8
+       adjust_dry_mass = .F.
+       consv_te = 0.
+       do_sat_adj = .T.
+       consv_am = .F.
+       fill = .T.
+       dwind_2d = .F.
+       print_freq = 6
+       warm_start = .F.
+       no_dycore = .false.
+       z_tracer = .T.
+       read_increment = .F.
+       res_latlon_dynamics = "fv3_increment.nc"
+
+       do_schmidt = .true.
+       target_lat = 15.0
+       target_lon = 146.0
+       stretch_fac = 1.5
+       regional = .true.
+       bc_update_interval = 3
+       agrid_vel_rst = .false.
+
+       full_zs_filter = .F. !unreleased feature
+
+       nord_zs_filter = 4
+       n_zs_filter = 0 ! safety
+/
+
+&surf_map_nml
+    zero_ocean = .F.
+    cd4 = 0.12
+    cd2 = -1
+    n_del2_strong = 0
+    n_del2_weak = 2
+    n_del4 = 1
+    max_slope = 0.4
+    peak_fac = 1.
+/
+
+ &external_ic_nml 
+       filtered_terrain = .true.
+       levp = 65
+       gfs_dwinds = .true.
+       checker_tr = .F.
+       nt_checker = 0
+/
+
+ &gfs_physics_nml
+       fhzero         = 1.
+       ldiag3d        = .false.
+       lradar         = .true.
+       avg_max_length = 3600.
+       h2o_phys       = .true.
+       fhcyc          = 24.
+       nst_anl        = .true.
+       use_ufo        = .true.
+       pre_rad        = .false.
+       ncld           = 5
+       imp_physics    = 11
+       pdfcld         = .false.
+       fhswr          = 3600.
+       fhlwr          = 3600.
+       ialb           = 1
+       iems           = 1
+       IAER           = 111
+       ico2           = 2
+       isubc_sw       = 2
+       isubc_lw       = 2
+       isol           = 2
+       lwhtr          = .true.
+       swhtr          = .true.
+       cnvgwd         = .false.
+       cal_pre        = .false.
+       redrag         = .true.
+       dspheat        = .true.
+       hybedmf        = .true.
+       random_clds    = .false.
+       trans_trac     = .true.
+       cnvcld         = .false.
+       imfshalcnv     = 2
+       imfdeepcnv     = 2
+       cdmbgwd        = 3.5, 0.01       ! NCEP default
+       prslrd0        = 0.
+       ivegsrc        = 1
+       isot           = 1
+       debug          = .false.
+       nstf_name      = 2,0,0,0,0
+       iau_delthrs    = 6
+       iaufhrs        = 30
+       iau_inc_files  = ''
+       shal_cnv = .false. !Shallow convection
+       do_deep = .false.
+       lgfdlmprad = .true.
+       effr_in = .true.
+/
+
+ &gfdl_cloud_microphysics_nml
+       sedi_transport = .false.
+       do_sedi_heat = .false.
+       rad_snow = .true.
+       rad_graupel = .true.
+       rad_rain = .true.
+       const_vi = .F.
+       const_vs = .F.
+       const_vg = .F.
+       const_vr = .F.
+       vi_max = 1.
+       vs_max = 2.
+       vg_max = 12.
+       vr_max = 12.
+       qi_lim = 1.
+       prog_ccn = .false.
+       do_qa = .true.
+       fast_sat_adj = .true.
+       tau_l2v = 180.
+       tau_v2l = 90.
+       tau_g2v = 900.
+       rthresh = 10.e-6  ! This is a key parameter for cloud water
+       dw_land  = 0.16
+       dw_ocean = 0.10
+       ql_gen = 1.0e-3
+       ql_mlt = 1.0e-3
+       qi0_crt = 8.0E-5
+       qs0_crt = 1.0e-3
+       tau_i2s = 1000.
+       c_psaci = 0.05
+       c_pgacs = 0.01
+       rh_inc = 0.30
+       rh_inr = 0.30
+       rh_ins = 0.30
+       ccn_l = 300.
+       ccn_o = 100.
+       c_paut = 0.5
+       c_cracw = 0.8
+       use_ppm = .false.
+       use_ccn = .true.
+       mono_prof = .true.
+       z_slope_liq  = .true.
+       z_slope_ice  = .true.
+       de_ice = .false.
+       fix_negative = .true.
+       icloud_f = 1
+       mp_time = 90.
+/
+  &interpolator_nml
+       interp_method = 'conserve_great_circle'
+/
+
+&namsfc
+       FNALBC2  = "C768.facsf.tileX.nc",
+       FNALBC   = "C768.snowfree_albedo.tileX.nc",
+       FNTG3C   = "C768.substrate_temperature.tileX.nc",
+       FNVEGC   = "C768.vegetation_greenness.tileX.nc",
+       FNVETC   = "C768.vegetation_type.tileX.nc",
+       FNSOTC   = "C768.soil_type.tileX.nc",
+       FNVMNC   = "C768.vegetation_greenness.tileX.nc",
+       FNVMXC   = "C768.vegetation_greenness.tileX.nc",
+       FNSLPC   = "C768.slope_type.tileX.nc",
+       FNABSC   = "C768.maximum_snow_albedo.tileX.nc",
+       FNGLAC   = "global_glacier.2x2.grb",
+       FNMXIC   = "global_maxice.2x2.grb",
+       FNTSFC   = "RTGSST.1982.2012.monthly.clim.grb",
+       FNSNOC   = "global_snoclim.1.875.grb",
+       FNZORC   = "igbp"
+       FNAISC   = "CFSR.SEAICE.1982.2012.monthly.clim.grb",
+       FNSMCC   = "global_soilmgldas.t1534.3072.1536.grb",
+       FNMSKH   = "seaice_newland.grb",
+       FNTSFA   = "",
+       FNACNA   = "",
+       FNSNOA   = "",
+       LDEBUG   =.true.,
+       FSMCL(2) = 99999
+       FSMCL(3) = 99999
+       FSMCL(4) = 99999
+       FTSFS    = 90
+       FAISS    = 99999
+       FSNOL    = 99999
+       FSICL    = 99999
+       FTSFL    = 99999,
+       FAISL    = 99999,
+       FVETL    = 99999,
+       FSOTL    = 99999,
+       FvmnL    = 99999,
+       FvmxL    = 99999,
+       FSLPL    = 99999,
+       FABSL    = 99999,
+       FSNOS    = 99999,
+       FSICS    = 99999,
+/
+&nam_stochy
+/
+&nam_sfcperts
+/

--- a/parm/input_sar_hi.nml
+++ b/parm/input_sar_hi.nml
@@ -1,0 +1,284 @@
+ &amip_interp_nml
+     interp_oi_sst = .true.
+     use_ncep_sst = .true.
+     use_ncep_ice = .false.
+     no_anom_sst = .false.
+     data_set = 'reynolds_oi',
+     date_out_of_range = 'climo',
+/
+
+ &atmos_model_nml
+     blocksize = 24
+     chksum_debug = .false.
+     dycore_only = .false.
+     fdiag = 1
+     avg_max_length = 3600.
+/
+
+&diag_manager_nml
+      prepend_date = .false.
+/
+
+ &fms_io_nml
+       checksum_required   = .false.
+       max_files_r = 100,
+       max_files_w = 100,
+/
+
+ &fms_nml
+       clock_grain = 'ROUTINE',
+       domains_stack_size = 1800200,
+       print_memory_usage = .false.
+/
+
+ &fv_grid_nml
+       grid_file = 'INPUT/grid_spec.nc'
+/
+
+ &fv_core_nml
+       layout   = 6,12
+       io_layout = 1,1
+       npx      = 433
+       npy      = 361
+       ntiles   = 1,
+       npz    = 64
+!       grid_type = -1
+       make_nh = .T.
+       fv_debug = .F.
+       range_warn = .F.
+       reset_eta = .F.
+       n_sponge = 24
+       nudge_qv = .F.
+       tau = 5.
+       rf_cutoff = 20.e2
+       d2_bg_k1 = 0.20
+       d2_bg_k2 = 0.04
+       kord_tm = -11
+       kord_mt =  11
+       kord_wz =  11
+       kord_tr =  11
+       hydrostatic = .F.
+       phys_hydrostatic = .F.
+       use_hydro_pressure = .F.
+       beta = 0.
+       a_imp = 1.
+       p_fac = 0.1
+       k_split  = 6
+       n_split  = 6
+       nwat = 6
+       na_init = 1
+       d_ext = 0.0
+       dnats = 1
+       fv_sg_adj = 300
+       d2_bg = 0.
+       nord =  2
+       dddmp = 0.1
+       d4_bg = 0.15
+       vtdm4 = 0.075
+       delt_max = 0.008
+       ke_bg = 0.
+       do_vort_damp = .true.
+       external_ic = .T.
+       external_eta = .T.
+       gfs_phil = .false.
+       nggps_ic = .T.
+       mountain = .F.
+       ncep_ic = .F.
+       d_con = 1.0
+       hord_mt = 6
+       hord_vt = 6
+       hord_tm = 6
+       hord_dp = -6
+       hord_tr = 8
+       adjust_dry_mass = .F.
+       consv_te = 0.
+       do_sat_adj = .T.
+       consv_am = .F.
+       fill = .T.
+       dwind_2d = .F.
+       print_freq = 6
+       warm_start = .F.
+       no_dycore = .false.
+       z_tracer = .T.
+       read_increment = .F.
+       res_latlon_dynamics = "fv3_increment.nc"
+
+       do_schmidt = .true.
+       target_lat = 20.0
+       target_lon = -157.0
+       stretch_fac = 1.5
+       regional = .true.
+       bc_update_interval = 3
+       agrid_vel_rst = .false.
+
+       full_zs_filter = .F. !unreleased feature
+
+       nord_zs_filter = 4
+       n_zs_filter = 0 ! safety
+/
+
+&surf_map_nml
+    zero_ocean = .F.
+    cd4 = 0.12
+    cd2 = -1
+    n_del2_strong = 0
+    n_del2_weak = 2
+    n_del4 = 1
+    max_slope = 0.4
+    peak_fac = 1.
+/
+
+ &external_ic_nml 
+       filtered_terrain = .true.
+       levp = 65
+       gfs_dwinds = .true.
+       checker_tr = .F.
+       nt_checker = 0
+/
+
+ &gfs_physics_nml
+       fhzero         = 1.
+       ldiag3d        = .false.
+       lradar         = .true.
+       avg_max_length = 3600.
+       h2o_phys       = .true.
+       fhcyc          = 24.
+       nst_anl        = .true.
+       use_ufo        = .true.
+       pre_rad        = .false.
+       ncld           = 5
+       imp_physics    = 11
+       pdfcld         = .false.
+       fhswr          = 3600.
+       fhlwr          = 3600.
+       ialb           = 1
+       iems           = 1
+       IAER           = 111
+       ico2           = 2
+       isubc_sw       = 2
+       isubc_lw       = 2
+       isol           = 2
+       lwhtr          = .true.
+       swhtr          = .true.
+       cnvgwd         = .false.
+       cal_pre        = .false.
+       redrag         = .true.
+       dspheat        = .true.
+       hybedmf        = .true.
+       random_clds    = .false.
+       trans_trac     = .true.
+       cnvcld         = .false.
+       imfshalcnv     = 2
+       imfdeepcnv     = 2
+       cdmbgwd        = 3.5, 0.01       ! NCEP default
+       prslrd0        = 0.
+       ivegsrc        = 1
+       isot           = 1
+       debug          = .false.
+       nstf_name      = 2,0,0,0,0
+       iau_delthrs    = 6
+       iaufhrs        = 30
+       iau_inc_files  = ''
+       shal_cnv = .false. !Shallow convection
+       do_deep = .false.
+       lgfdlmprad = .true.
+       effr_in = .true.
+/
+
+ &gfdl_cloud_microphysics_nml
+       sedi_transport = .false.
+       do_sedi_heat = .false.
+       rad_snow = .true.
+       rad_graupel = .true.
+       rad_rain = .true.
+       const_vi = .F.
+       const_vs = .F.
+       const_vg = .F.
+       const_vr = .F.
+       vi_max = 1.
+       vs_max = 2.
+       vg_max = 12.
+       vr_max = 12.
+       qi_lim = 1.
+       prog_ccn = .false.
+       do_qa = .true.
+       fast_sat_adj = .true.
+       tau_l2v = 180.
+       tau_v2l = 90.
+       tau_g2v = 900.
+       rthresh = 10.e-6  ! This is a key parameter for cloud water
+       dw_land  = 0.16
+       dw_ocean = 0.10
+       ql_gen = 1.0e-3
+       ql_mlt = 1.0e-3
+       qi0_crt = 8.0E-5
+       qs0_crt = 1.0e-3
+       tau_i2s = 1000.
+       c_psaci = 0.05
+       c_pgacs = 0.01
+       rh_inc = 0.30
+       rh_inr = 0.30
+       rh_ins = 0.30
+       ccn_l = 300.
+       ccn_o = 100.
+       c_paut = 0.5
+       c_cracw = 0.8
+       use_ppm = .false.
+       use_ccn = .true.
+       mono_prof = .true.
+       z_slope_liq  = .true.
+       z_slope_ice  = .true.
+       de_ice = .false.
+       fix_negative = .true.
+       icloud_f = 1
+       mp_time = 90.
+/
+  &interpolator_nml
+       interp_method = 'conserve_great_circle'
+/
+
+&namsfc
+       FNALBC2  = "C768.facsf.tileX.nc",
+       FNALBC   = "C768.snowfree_albedo.tileX.nc",
+       FNTG3C   = "C768.substrate_temperature.tileX.nc",
+       FNVEGC   = "C768.vegetation_greenness.tileX.nc",
+       FNVETC   = "C768.vegetation_type.tileX.nc",
+       FNSOTC   = "C768.soil_type.tileX.nc",
+       FNVMNC   = "C768.vegetation_greenness.tileX.nc",
+       FNVMXC   = "C768.vegetation_greenness.tileX.nc",
+       FNSLPC   = "C768.slope_type.tileX.nc",
+       FNABSC   = "C768.maximum_snow_albedo.tileX.nc",
+       FNGLAC   = "global_glacier.2x2.grb",
+       FNMXIC   = "global_maxice.2x2.grb",
+       FNTSFC   = "RTGSST.1982.2012.monthly.clim.grb",
+       FNSNOC   = "global_snoclim.1.875.grb",
+       FNZORC   = "igbp"
+       FNAISC   = "CFSR.SEAICE.1982.2012.monthly.clim.grb",
+       FNSMCC   = "global_soilmgldas.t1534.3072.1536.grb",
+       FNMSKH   = "seaice_newland.grb",
+       FNTSFA   = "",
+       FNACNA   = "",
+       FNSNOA   = "",
+       LDEBUG   =.true.,
+       FSMCL(2) = 99999
+       FSMCL(3) = 99999
+       FSMCL(4) = 99999
+       FTSFS    = 90
+       FAISS    = 99999
+       FSNOL    = 99999
+       FSICL    = 99999
+       FTSFL    = 99999,
+       FAISL    = 99999,
+       FVETL    = 99999,
+       FSOTL    = 99999,
+       FvmnL    = 99999,
+       FvmxL    = 99999,
+       FSLPL    = 99999,
+       FABSL    = 99999,
+       FSNOS    = 99999,
+       FSICS    = 99999,
+/
+&nam_stochy
+/
+&nam_sfcperts
+/

--- a/parm/input_sar_pr.nml
+++ b/parm/input_sar_pr.nml
@@ -1,0 +1,284 @@
+ &amip_interp_nml
+     interp_oi_sst = .true.
+     use_ncep_sst = .true.
+     use_ncep_ice = .false.
+     no_anom_sst = .false.
+     data_set = 'reynolds_oi',
+     date_out_of_range = 'climo',
+/
+
+ &atmos_model_nml
+     blocksize = 24
+     chksum_debug = .false.
+     dycore_only = .false.
+     fdiag = 1
+     avg_max_length = 3600.
+/
+
+&diag_manager_nml
+      prepend_date = .false.
+/
+
+ &fms_io_nml
+       checksum_required   = .false.
+       max_files_r = 100,
+       max_files_w = 100,
+/
+
+ &fms_nml
+       clock_grain = 'ROUTINE',
+       domains_stack_size = 1800200,
+       print_memory_usage = .false.
+/
+
+ &fv_grid_nml
+       grid_file = 'INPUT/grid_spec.nc'
+/
+
+ &fv_core_nml
+       layout   = 6,18
+       io_layout = 1,1
+       npx      = 577
+       npy      = 433
+       ntiles   = 1,
+       npz    = 64
+!       grid_type = -1
+       make_nh = .T.
+       fv_debug = .F.
+       range_warn = .F.
+       reset_eta = .F.
+       n_sponge = 24
+       nudge_qv = .F.
+       tau = 5.
+       rf_cutoff = 20.e2
+       d2_bg_k1 = 0.20
+       d2_bg_k2 = 0.04
+       kord_tm = -11
+       kord_mt =  11
+       kord_wz =  11
+       kord_tr =  11
+       hydrostatic = .F.
+       phys_hydrostatic = .F.
+       use_hydro_pressure = .F.
+       beta = 0.
+       a_imp = 1.
+       p_fac = 0.1
+       k_split  = 6
+       n_split  = 6
+       nwat = 6
+       na_init = 1
+       d_ext = 0.0
+       dnats = 1
+       fv_sg_adj = 300
+       d2_bg = 0.
+       nord =  2
+       dddmp = 0.1
+       d4_bg = 0.15
+       vtdm4 = 0.075
+       delt_max = 0.008
+       ke_bg = 0.
+       do_vort_damp = .true.
+       external_ic = .T.
+       external_eta = .T.
+       gfs_phil = .false.
+       nggps_ic = .T.
+       mountain = .F.
+       ncep_ic = .F.
+       d_con = 1.0
+       hord_mt = 6
+       hord_vt = 6
+       hord_tm = 6
+       hord_dp = -6
+       hord_tr = 8
+       adjust_dry_mass = .F.
+       consv_te = 0.
+       do_sat_adj = .T.
+       consv_am = .F.
+       fill = .T.
+       dwind_2d = .F.
+       print_freq = 6
+       warm_start = .F.
+       no_dycore = .false.
+       z_tracer = .T.
+       read_increment = .F.
+       res_latlon_dynamics = "fv3_increment.nc"
+
+       do_schmidt = .true.
+       target_lat = 18.0
+       target_lon = -69.0
+       stretch_fac = 1.5
+       regional = .true.
+       bc_update_interval = 3
+       agrid_vel_rst = .false.
+
+       full_zs_filter = .F. !unreleased feature
+
+       nord_zs_filter = 4
+       n_zs_filter = 0 ! safety
+/
+
+&surf_map_nml
+    zero_ocean = .F.
+    cd4 = 0.12
+    cd2 = -1
+    n_del2_strong = 0
+    n_del2_weak = 2
+    n_del4 = 1
+    max_slope = 0.4
+    peak_fac = 1.
+/
+
+ &external_ic_nml 
+       filtered_terrain = .true.
+       levp = 65
+       gfs_dwinds = .true.
+       checker_tr = .F.
+       nt_checker = 0
+/
+
+ &gfs_physics_nml
+       fhzero         = 1.
+       ldiag3d        = .false.
+       lradar         = .true.
+       avg_max_length = 3600.
+       h2o_phys       = .true.
+       fhcyc          = 24.
+       nst_anl        = .true.
+       use_ufo        = .true.
+       pre_rad        = .false.
+       ncld           = 5
+       imp_physics    = 11
+       pdfcld         = .false.
+       fhswr          = 3600.
+       fhlwr          = 3600.
+       ialb           = 1
+       iems           = 1
+       IAER           = 111
+       ico2           = 2
+       isubc_sw       = 2
+       isubc_lw       = 2
+       isol           = 2
+       lwhtr          = .true.
+       swhtr          = .true.
+       cnvgwd         = .false.
+       cal_pre        = .false.
+       redrag         = .true.
+       dspheat        = .true.
+       hybedmf        = .true.
+       random_clds    = .false.
+       trans_trac     = .true.
+       cnvcld         = .false.
+       imfshalcnv     = 2
+       imfdeepcnv     = 2
+       cdmbgwd        = 3.5, 0.01       ! NCEP default
+       prslrd0        = 0.
+       ivegsrc        = 1
+       isot           = 1
+       debug          = .false.
+       nstf_name      = 2,0,0,0,0
+       iau_delthrs    = 6
+       iaufhrs        = 30
+       iau_inc_files  = ''
+       shal_cnv = .false. !Shallow convection
+       do_deep = .false.
+       lgfdlmprad = .true.
+       effr_in = .true.
+/
+
+ &gfdl_cloud_microphysics_nml
+       sedi_transport = .false.
+       do_sedi_heat = .false.
+       rad_snow = .true.
+       rad_graupel = .true.
+       rad_rain = .true.
+       const_vi = .F.
+       const_vs = .F.
+       const_vg = .F.
+       const_vr = .F.
+       vi_max = 1.
+       vs_max = 2.
+       vg_max = 12.
+       vr_max = 12.
+       qi_lim = 1.
+       prog_ccn = .false.
+       do_qa = .true.
+       fast_sat_adj = .true.
+       tau_l2v = 180.
+       tau_v2l = 90.
+       tau_g2v = 900.
+       rthresh = 10.e-6  ! This is a key parameter for cloud water
+       dw_land  = 0.16
+       dw_ocean = 0.10
+       ql_gen = 1.0e-3
+       ql_mlt = 1.0e-3
+       qi0_crt = 8.0E-5
+       qs0_crt = 1.0e-3
+       tau_i2s = 1000.
+       c_psaci = 0.05
+       c_pgacs = 0.01
+       rh_inc = 0.30
+       rh_inr = 0.30
+       rh_ins = 0.30
+       ccn_l = 300.
+       ccn_o = 100.
+       c_paut = 0.5
+       c_cracw = 0.8
+       use_ppm = .false.
+       use_ccn = .true.
+       mono_prof = .true.
+       z_slope_liq  = .true.
+       z_slope_ice  = .true.
+       de_ice = .false.
+       fix_negative = .true.
+       icloud_f = 1
+       mp_time = 90.
+/
+  &interpolator_nml
+       interp_method = 'conserve_great_circle'
+/
+
+&namsfc
+       FNALBC2  = "C768.facsf.tileX.nc",
+       FNALBC   = "C768.snowfree_albedo.tileX.nc",
+       FNTG3C   = "C768.substrate_temperature.tileX.nc",
+       FNVEGC   = "C768.vegetation_greenness.tileX.nc",
+       FNVETC   = "C768.vegetation_type.tileX.nc",
+       FNSOTC   = "C768.soil_type.tileX.nc",
+       FNVMNC   = "C768.vegetation_greenness.tileX.nc",
+       FNVMXC   = "C768.vegetation_greenness.tileX.nc",
+       FNSLPC   = "C768.slope_type.tileX.nc",
+       FNABSC   = "C768.maximum_snow_albedo.tileX.nc",
+       FNGLAC   = "global_glacier.2x2.grb",
+       FNMXIC   = "global_maxice.2x2.grb",
+       FNTSFC   = "RTGSST.1982.2012.monthly.clim.grb",
+       FNSNOC   = "global_snoclim.1.875.grb",
+       FNZORC   = "igbp"
+       FNAISC   = "CFSR.SEAICE.1982.2012.monthly.clim.grb",
+       FNSMCC   = "global_soilmgldas.t1534.3072.1536.grb",
+       FNMSKH   = "seaice_newland.grb",
+       FNTSFA   = "",
+       FNACNA   = "",
+       FNSNOA   = "",
+       LDEBUG   =.true.,
+       FSMCL(2) = 99999
+       FSMCL(3) = 99999
+       FSMCL(4) = 99999
+       FTSFS    = 90
+       FAISS    = 99999
+       FSNOL    = 99999
+       FSICL    = 99999
+       FTSFL    = 99999,
+       FAISL    = 99999,
+       FVETL    = 99999,
+       FSOTL    = 99999,
+       FvmnL    = 99999,
+       FvmxL    = 99999,
+       FSLPL    = 99999,
+       FABSL    = 99999,
+       FSNOS    = 99999,
+       FSICS    = 99999,
+/
+&nam_stochy
+/
+&nam_sfcperts
+/

--- a/parm/model_configure_sar.tmp_ak
+++ b/parm/model_configure_sar.tmp_ak
@@ -1,0 +1,58 @@
+print_esmf:              .false.
+total_member:            1
+PE_MEMBER01:             NTASKS
+start_year:              YR
+start_month:             MN
+start_day:               DY
+start_hour:              H_R
+start_minute:            0
+start_second:            0
+nhours_fcst:             NHRS
+RUN_CONTINUE:            .false.
+ENS_SPS:                 .false.
+dt_atmos:                90
+cpl:                     .false.
+calendar:                'julian'
+memuse_verbose:          .false.
+atmos_nthreads:          NTHRD
+use_hyper_thread:        .false.
+ncores_per_node:         NCNODE
+debug_affinity:          .true.
+restart_interval:        12
+output_1st_tstep_rst:    .false.
+
+quilting:                .true.
+write_groups:            2
+write_tasks_per_group:   24
+num_files:               2
+filename_base:           'dyn''phy'
+output_file:             'netcdf'
+write_nemsioflip:        .false.
+write_fsyncflag:         .false.
+
+output_grid:             'rotated_latlon'
+cen_lon:                 -153.0  # central longitude
+cen_lat:                 61.0   # central latitude
+lon1:                    -18.0  # longitude of lower-left point in rotated coordinate system (in degrees)
+lat1:                    -14.79  # latitude of lower-left ...
+lon2:                    18.0   # longitude of upper-right ...
+lat2:                    14.79   # latitude of upper-right ...
+dlon:                    0.03
+dlat:                    0.03
+
+#output_grid:		 'lambert_conformal'
+#cen_lon:		 -97.5	 # central longitude
+#cen_lat:		 38.5	 # central latitude
+#stdlat1:		 38.5
+#stdlat2:		 38.5
+#nx:			 1799	 # number of points along x-axis.
+#ny:			 1059	 # number of points along y-axis.
+#lon1:			 -122.719528	# longitude of lower-left point (in degrees)
+#lat1:			 21.138123	# latitude of lower-left point (in degrees)
+#dx:			 3000.0	 # x-direction grid length
+#dy:			 3000.0  # y-direction grid length
+
+nfhout:                  1
+nfhmax_hf:               60
+nfhout_hf:               1
+nsout:                   -1

--- a/parm/model_configure_sar.tmp_conus
+++ b/parm/model_configure_sar.tmp_conus
@@ -1,0 +1,58 @@
+print_esmf:              .false.
+total_member:            1
+PE_MEMBER01:             NTASKS
+start_year:              YR
+start_month:             MN
+start_day:               DY
+start_hour:              H_R
+start_minute:            0
+start_second:            0
+nhours_fcst:             NHRS
+RUN_CONTINUE:            .false.
+ENS_SPS:                 .false.
+dt_atmos:                90
+cpl:                     .false.
+calendar:                'julian'
+memuse_verbose:          .false.
+atmos_nthreads:          NTHRD
+use_hyper_thread:        .false.
+ncores_per_node:         NCNODE
+debug_affinity:          .true.
+restart_interval:        12
+output_1st_tstep_rst:    .false.
+
+quilting:                .true.
+write_groups:            3
+write_tasks_per_group:   72
+num_files:               2
+filename_base:           'dyn''phy'
+output_file:             'netcdf'
+write_nemsioflip:        .false.
+write_fsyncflag:         .false.
+
+output_grid:             'rotated_latlon'
+cen_lon:                 -97.5  # central longitude
+cen_lat:                 38.5   # central latitude
+lon1:                    -25.0  # longitude of lower-left point in rotated coordinate system (in degrees)
+lat1:                    -15.0  # latitude of lower-left ...
+lon2:                    25.0   # longitude of upper-right ...
+lat2:                    15.0   # latitude of upper-right ...
+dlon:                    0.02
+dlat:                    0.02
+
+#output_grid:		 'lambert_conformal'
+#cen_lon:		 -97.5	 # central longitude
+#cen_lat:		 38.5	 # central latitude
+#stdlat1:		 38.5
+#stdlat2:		 38.5
+#nx:			 1799	 # number of points along x-axis.
+#ny:			 1059	 # number of points along y-axis.
+#lon1:			 -122.719528	# longitude of lower-left point (in degrees)
+#lat1:			 21.138123	# latitude of lower-left point (in degrees)
+#dx:			 3000.0	 # x-direction grid length
+#dy:			 3000.0  # y-direction grid length
+
+nfhout:                  1
+nfhmax_hf:               60
+nfhout_hf:               1
+nsout:                   -1

--- a/parm/model_configure_sar.tmp_conus
+++ b/parm/model_configure_sar.tmp_conus
@@ -23,7 +23,7 @@ output_1st_tstep_rst:    .false.
 
 quilting:                .true.
 write_groups:            3
-write_tasks_per_group:   72
+write_tasks_per_group:   48
 num_files:               2
 filename_base:           'dyn''phy'
 output_file:             'netcdf'

--- a/parm/model_configure_sar.tmp_guam
+++ b/parm/model_configure_sar.tmp_guam
@@ -1,0 +1,58 @@
+print_esmf:              .false.
+total_member:            1
+PE_MEMBER01:             NTASKS
+start_year:              YR
+start_month:             MN
+start_day:               DY
+start_hour:              H_R
+start_minute:            0
+start_second:            0
+nhours_fcst:             NHRS
+RUN_CONTINUE:            .false.
+ENS_SPS:                 .false.
+dt_atmos:                90
+cpl:                     .false.
+calendar:                'julian'
+memuse_verbose:          .false.
+atmos_nthreads:          NTHRD
+use_hyper_thread:        .false.
+ncores_per_node:         NCNODE
+debug_affinity:          .true.
+restart_interval:        12
+output_1st_tstep_rst:    .false.
+
+quilting:                .true.
+write_groups:            1
+write_tasks_per_group:   12
+num_files:               2
+filename_base:           'dyn''phy'
+output_file:             'netcdf'
+write_nemsioflip:        .false.
+write_fsyncflag:         .false.
+
+output_grid:             'rotated_latlon'
+cen_lon:                 146.0  # central longitude
+cen_lat:                 15.0   # central latitude
+lon1:                    -5.6  # longitude of lower-left point in rotated coordinate system (in degrees)
+lat1:                    -4.8  # latitude of lower-left ...
+lon2:                    5.6   # longitude of upper-right ...
+lat2:                    4.8   # latitude of upper-right ...
+dlon:                    0.025
+dlat:                    0.025
+
+#output_grid:		 'lambert_conformal'
+#cen_lon:		 -97.5	 # central longitude
+#cen_lat:		 38.5	 # central latitude
+#stdlat1:		 38.5
+#stdlat2:		 38.5
+#nx:			 1799	 # number of points along x-axis.
+#ny:			 1059	 # number of points along y-axis.
+#lon1:			 -122.719528	# longitude of lower-left point (in degrees)
+#lat1:			 21.138123	# latitude of lower-left point (in degrees)
+#dx:			 3000.0	 # x-direction grid length
+#dy:			 3000.0  # y-direction grid length
+
+nfhout:                  1
+nfhmax_hf:               60
+nfhout_hf:               1
+nsout:                   -1

--- a/parm/model_configure_sar.tmp_hi
+++ b/parm/model_configure_sar.tmp_hi
@@ -1,0 +1,58 @@
+print_esmf:              .false.
+total_member:            1
+PE_MEMBER01:             NTASKS
+start_year:              YR
+start_month:             MN
+start_day:               DY
+start_hour:              H_R
+start_minute:            0
+start_second:            0
+nhours_fcst:             NHRS
+RUN_CONTINUE:            .false.
+ENS_SPS:                 .false.
+dt_atmos:                90
+cpl:                     .false.
+calendar:                'julian'
+memuse_verbose:          .false.
+atmos_nthreads:          NTHRD
+use_hyper_thread:        .false.
+ncores_per_node:         NCNODE
+debug_affinity:          .true.
+restart_interval:        12
+output_1st_tstep_rst:    .false.
+
+quilting:                .true.
+write_groups:            1
+write_tasks_per_group:   12
+num_files:               2
+filename_base:           'dyn''phy'
+output_file:             'netcdf'
+write_nemsioflip:        .false.
+write_fsyncflag:         .false.
+
+output_grid:             'rotated_latlon'
+cen_lon:                 -157.0  # central longitude
+cen_lat:                 20.0   # central latitude
+lon1:                    -5.4  # longitude of lower-left point in rotated coordinate system (in degrees)
+lat1:                    -4.3  # latitude of lower-left ...
+lon2:                    5.4   # longitude of upper-right ...
+lat2:                    4.3   # latitude of upper-right ...
+dlon:                    0.025
+dlat:                    0.025
+
+#output_grid:		 'lambert_conformal'
+#cen_lon:		 -97.5	 # central longitude
+#cen_lat:		 38.5	 # central latitude
+#stdlat1:		 38.5
+#stdlat2:		 38.5
+#nx:			 1799	 # number of points along x-axis.
+#ny:			 1059	 # number of points along y-axis.
+#lon1:			 -122.719528	# longitude of lower-left point (in degrees)
+#lat1:			 21.138123	# latitude of lower-left point (in degrees)
+#dx:			 3000.0	 # x-direction grid length
+#dy:			 3000.0  # y-direction grid length
+
+nfhout:                  1
+nfhmax_hf:               60
+nfhout_hf:               1
+nsout:                   -1

--- a/parm/model_configure_sar.tmp_pr
+++ b/parm/model_configure_sar.tmp_pr
@@ -1,0 +1,58 @@
+print_esmf:              .false.
+total_member:            1
+PE_MEMBER01:             NTASKS
+start_year:              YR
+start_month:             MN
+start_day:               DY
+start_hour:              H_R
+start_minute:            0
+start_second:            0
+nhours_fcst:             NHRS
+RUN_CONTINUE:            .false.
+ENS_SPS:                 .false.
+dt_atmos:                90
+cpl:                     .false.
+calendar:                'julian'
+memuse_verbose:          .false.
+atmos_nthreads:          NTHRD
+use_hyper_thread:        .false.
+ncores_per_node:         NCNODE
+debug_affinity:          .true.
+restart_interval:        12
+output_1st_tstep_rst:    .false.
+
+quilting:                .true.
+write_groups:            1
+write_tasks_per_group:   12
+num_files:               2
+filename_base:           'dyn''phy'
+output_file:             'netcdf'
+write_nemsioflip:        .false.
+write_fsyncflag:         .false.
+
+output_grid:             'rotated_latlon'
+cen_lon:                 -69.0  # central longitude
+cen_lat:                 18.0   # central latitude
+lon1:                    -7.8  # longitude of lower-left point in rotated coordinate system (in degrees)
+lat1:                    -5.2  # latitude of lower-left ...
+lon2:                    7.8   # longitude of upper-right ...
+lat2:                    5.2   # latitude of upper-right ...
+dlon:                    0.025
+dlat:                    0.025
+
+#output_grid:		 'lambert_conformal'
+#cen_lon:		 -97.5	 # central longitude
+#cen_lat:		 38.5	 # central latitude
+#stdlat1:		 38.5
+#stdlat2:		 38.5
+#nx:			 1799	 # number of points along x-axis.
+#ny:			 1059	 # number of points along y-axis.
+#lon1:			 -122.719528	# longitude of lower-left point (in degrees)
+#lat1:			 21.138123	# latitude of lower-left point (in degrees)
+#dx:			 3000.0	 # x-direction grid length
+#dy:			 3000.0  # y-direction grid length
+
+nfhout:                  1
+nfhmax_hf:               60
+nfhout_hf:               1
+nsout:                   -1

--- a/rocoto/drive_fv3sar.xml
+++ b/rocoto/drive_fv3sar.xml
@@ -18,6 +18,7 @@
 
 <!ENTITY HOMEfv3 "/gpfs/dell2/emc/modeling/noscrub/&USER;/fv3cam_workflow">
 <!ENTITY JOBS "&HOMEfv3;/jobs">
+<!ENTITY domain "conus">
 <!ENTITY SCRIPTS "&HOMEfv3;/scripts">
 <!ENTITY COMgfs "/gpfs/dell1/nco/ops/com/gfs/prod">
 <!ENTITY COMgfs2 "/gpfs/dell3/ptmp/emc.glopara/ROTDIRS/prfv3rt3/vrfyarch">

--- a/rocoto/drive_fv3sar_ak.xml
+++ b/rocoto/drive_fv3sar_ak.xml
@@ -1,0 +1,639 @@
+<?xml version="1.0"?>
+<!DOCTYPE workflow
+[
+
+<!ENTITY STARTYEAR "2019">
+<!ENTITY STARTMONTH "06">
+<!ENTITY STARTDAY "19">
+<!ENTITY STARTHOUR "06">
+
+<!ENTITY ENDYEAR "2020">
+<!ENTITY ENDMONTH "12">
+<!ENTITY ENDDAY "31">
+<!ENTITY ENDHOUR "18">
+
+<!ENTITY USER "Matthew.Pyle">
+<!ENTITY machine "DELL">
+<!ENTITY ACCOUNT "FV3GFS-T2O">
+
+<!ENTITY HOMEfv3 "/gpfs/dell2/emc/modeling/noscrub/&USER;/fv3sar_workflow">
+<!ENTITY domain "ak">
+<!ENTITY JOBS "&HOMEfv3;/jobs">
+<!ENTITY SCRIPTS "&HOMEfv3;/scripts">
+<!ENTITY COMgfs "/gpfs/dell1/nco/ops/com/gfs/prod">
+<!ENTITY COMgfs2 "/gpfs/dell3/ptmp/emc.glopara/ROTDIRS/prfv3rt3/vrfyarch">
+<!ENTITY OUTDIR "/gpfs/dell1/ptmp/&USER;">
+<!ENTITY DATAROOT "/gpfs/dell1/stmp/&USER;/tmpnwprd">
+
+<!ENTITY RESERVATION '<queue>dev</queue><account>&ACCOUNT;</account>'>
+<!ENTITY RESERVATION_TRANSFER '<queue>dev_transfer</queue><account>&ACCOUNT;</account>'>
+
+<!ENTITY CLEANUP_RESOURCES '<walltime>00:10:00</walltime>'>
+<!ENTITY CHGRES_IC_RESOURCES '<walltime>00:15:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY CHGRES_BC_RESOURCES '<walltime>00:12:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY FCST_RESOURCES '<walltime>01:20:00</walltime><native>-R affinity[core\(2\):distribute=balance]</native>'>
+<!ENTITY POST_RESOURCES '<walltime>00:20:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY POSTGOES_RESOURCES '<walltime>00:10:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY HIST_RESOURCES '<walltime>00:30:00</walltime><memory>5G</memory><native>-R affinity[core]</native>'>
+
+]>
+
+
+<!--  ************************************************************* -->
+<!--  ******************* STARTING THE WORKFLOW ******************* -->
+
+<!-- <workflow realtime="F" scheduler="lsf" taskthrottle="11"> -->
+<workflow realtime="T" scheduler="lsf" taskthrottle="60" cyclethrottle="1" cyclelifespan="00:24:00:00">
+
+  <cycledef group="regional">&STARTYEAR;&STARTMONTH;&STARTDAY;&STARTHOUR;00 &ENDYEAR;&ENDMONTH;&ENDDAY;&ENDHOUR;00 12:00:00</cycledef>
+
+  <log>
+    <cyclestr>&OUTDIR;/logfiles_sar/workflow_regional_&domain;_@Y@m@d@H.log</cyclestr>
+  </log>
+
+
+<!--  **********************************************************************  -->
+<!--  **************************** Run chgres ******************************  -->
+
+<!-- Create the initial conditions and boundary condition hour 0 from the FV3GFS -->
+
+  <task name="chgres_firstguess" cycledefs="regional" maxtries="3">
+  &RESERVATION;
+  &CHGRES_IC_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_CHGRES_FIRSTGUESS</command>
+    <jobname><cyclestr>chgres_firstguess_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/chgres_firstguess_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>chgres_firstguess_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+
+    <dependency>
+      <or>
+        <and>
+          <datadep age="10:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf000.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="15779010324"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmanl.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="1170221688"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.sfcanl.nemsio</cyclestr></datadep>
+        </and>
+        <and>
+          <datadep age="10:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf000.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="15779010324"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmanl.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="1170221688"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.sfcanl.nemsio</cyclestr></datadep>
+        </and>
+      </or>
+    </dependency>
+
+  </task>
+
+
+<!-- Create the boundary conditions from the FV3GFS -->
+
+  <task name="chgres_fcstbndy" cycledefs="regional" maxtries="3">
+  &RESERVATION;
+  &CHGRES_BC_RESOURCES;
+  <nodes>20:ppn=1</nodes>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_CHGRES_FCSTBNDY</command>
+    <jobname><cyclestr>chgres_fcstbndy_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/chgres_fcstbndy_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>chgres_fcstbndy_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <or>
+        <and>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf057.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf060.nemsio</cyclestr></datadep>
+        </and>
+        <and>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf009.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf060.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf063.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf066.nemsio</cyclestr></datadep>
+        </and>
+      </or>
+    </dependency>
+
+  </task>
+
+
+<!--  ***********************************************************************  -->
+<!--  ************************* Run the forecast ****************************  -->
+
+  <task name="forecast_tm00" cycledefs="regional" maxtries="1">
+  &RESERVATION;
+  &FCST_RESOURCES;
+  <nodes>68:ppn=12</nodes>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_FCST</command>
+    <jobname><cyclestr>forecast_tm00_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/forecast_tm00_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value><cyclestr>forecast_tm00_&domain;_@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="chgres_firstguess"/>
+        <taskdep task="chgres_fcstbndy"/>
+      </and>
+    </dependency>
+
+  </task>
+
+<!--  *******************************************************************  -->
+<!--  ********************** Run the post processor *********************  -->
+
+  <metatask>
+    <var name="fhr">00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60</var>
+    <task name="post#fhr#" cycledefs="regional" maxtries="2">
+    &RESERVATION;
+    &POST_RESOURCES;
+    <nodes>2:ppn=14</nodes>
+      <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_POST</command>
+      <jobname><cyclestr>fv3_post_&domain;_f#fhr#_@Hz</cyclestr></jobname>
+      <join><cyclestr>&OUTDIR;/logfiles_sar/post_&domain;_f#fhr#_@H_tm00.log</cyclestr></join>
+   
+      <envar>
+        <name>HOMEfv3</name>
+        <value>&HOMEfv3;</value>
+      </envar>
+      <envar>
+        <name>job</name>
+        <value>post_&domain;_f#fhr#</value>
+      </envar>
+      <envar>
+        <name>machine</name>
+        <value>&machine;</value>
+      </envar>
+      <envar>
+        <name>USER</name>
+        <value>&USER;</value>
+      </envar>
+      <envar>
+        <name>CDATE</name>
+        <value><cyclestr>@Y@m@d@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>PDY</name>
+        <value><cyclestr>@Y@m@d</cyclestr></value>
+      </envar>
+      <envar>
+        <name>cyc</name>
+        <value><cyclestr>@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>fhr</name>
+        <value>#fhr#</value>
+      </envar>
+      <envar>
+        <name>tmmark</name>
+        <value>tm00</value>
+      </envar>
+      <envar>
+       <name>dom</name>
+       <value>&domain;</value>
+      </envar>
+
+      <dependency>
+        <and>
+          <datadep age="05:00"><cyclestr>&DATAROOT;/forecast_tm00_&domain;_@Y@m@d_@H/logf0#fhr#</cyclestr></datadep>
+        </and>
+      </dependency>
+    </task>
+  </metatask>
+
+  <metatask name="postgoes" throttle="12">
+    <var name="fhr">00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60</var>
+    <task name="postgoes#fhr#" cycledefs="regional" maxtries="1">
+    &RESERVATION;
+    &POSTGOES_RESOURCES;
+    <nodes>2:ppn=14</nodes>
+      <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_POST_GOES</command>
+      <jobname><cyclestr>fv3_postgoes_&domain;_f#fhr#_@Hz</cyclestr></jobname>
+      <join><cyclestr>&OUTDIR;/logfiles_sar/postgoes_&domain;_f#fhr#_@H_tm00.log</cyclestr></join>
+   
+      <envar>
+        <name>HOMEfv3</name>
+        <value>&HOMEfv3;</value>
+      </envar>
+      <envar>
+        <name>job</name>
+        <value>postgoes_&domain;_f#fhr#</value>
+      </envar>
+      <envar>
+        <name>machine</name>
+        <value>&machine;</value>
+      </envar>
+      <envar>
+        <name>USER</name>
+        <value>&USER;</value>
+      </envar>
+      <envar>
+        <name>CDATE</name>
+        <value><cyclestr>@Y@m@d@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>PDY</name>
+        <value><cyclestr>@Y@m@d</cyclestr></value>
+      </envar>
+      <envar>
+        <name>cyc</name>
+        <value><cyclestr>@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>fhr</name>
+        <value>#fhr#</value>
+      </envar>
+      <envar>
+        <name>tmmark</name>
+        <value>tm00</value>
+      </envar>
+      <envar>
+       <name>dom</name>
+       <value>&domain;</value>
+      </envar>
+
+      <dependency>
+        <and>
+          <datadep age="05:00"><cyclestr>&DATAROOT;/forecast_tm00_&domain;_@Y@m@d_@H/logf0#fhr#</cyclestr></datadep>
+        </and>
+      </dependency>
+    </task>
+  </metatask>
+
+
+<!-- *********************************************************************** -->
+<!-- ***************************** Archive job ***************************** -->
+
+<!--  <task name="rhist" cycledefs="regional" maxtries="2">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_RHIST</command>
+    <jobname><cyclestr>run_history_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/rhist_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value><cyclestr>jrun_history@H_&domain;_fv3sar</cyclestr></value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="post60"/>
+      </and>
+    </dependency>
+  </task> -->
+
+
+<!-- ******************************************************************* -->
+<!-- ************************* FTP transfers *************************** -->
+
+<!--  <task name="sendinibc" cycledefs="regional" maxtries="1">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_SENDINIBC</command>
+    <jobname><cyclestr>sendinibc_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/sendinibc_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>sendinibc_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="chgres_firstguess"/>
+        <taskdep task="chgres_fcstbndy"/>
+      </and>
+    </dependency>
+  </task>
+
+  <task name="sendpost" cycledefs="regional" maxtries="1">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_SENDPOST</command>
+    <jobname><cyclestr>sendpost_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/sendpost_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>sendpost_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="post60"/>
+      </and>
+    </dependency>
+  </task>
+
+  <task name="sendpostgoes" cycledefs="regional" maxtries="1">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_SENDPOST_GOES</command>
+    <jobname><cyclestr>sendpostgoes_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/sendpostgoes_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>sendpostgoes_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="postgoes60"/>
+      </and>
+    </dependency>
+  </task> -->
+
+<!--  **********************************************************************  -->
+<!--  ******************************* Cleanup ******************************  -->
+
+<!--  <task name="cleanup" cycledefs="regional" maxtries="2">
+  &RESERVATION;
+  &CLEANUP_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_CLEANUP</command>
+    <jobname><cyclestr>cleanup_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/cleanup_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>cleanup_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATEm2</name>
+      <value><cyclestr offset="-00:48:00:00">@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="post60"/>
+        <taskdep task="postgoes60"/>
+      </and>
+    </dependency>
+
+  </task> -->
+
+
+</workflow>

--- a/rocoto/drive_fv3sar_conus.xml
+++ b/rocoto/drive_fv3sar_conus.xml
@@ -192,7 +192,7 @@
   <task name="forecast_tm00" cycledefs="regional" maxtries="1">
   &RESERVATION;
   &FCST_RESOURCES;
-  <nodes>114:ppn=12</nodes>
+  <nodes>76:ppn=12</nodes>
     <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_FCST</command>
     <jobname><cyclestr>forecast_tm00_&domain;_@H</cyclestr></jobname>
     <join><cyclestr>&OUTDIR;/logfiles_sar/forecast_tm00_&domain;_@H.log</cyclestr></join>

--- a/rocoto/drive_fv3sar_conus.xml
+++ b/rocoto/drive_fv3sar_conus.xml
@@ -1,0 +1,639 @@
+<?xml version="1.0"?>
+<!DOCTYPE workflow
+[
+
+<!ENTITY STARTYEAR "2019">
+<!ENTITY STARTMONTH "06">
+<!ENTITY STARTDAY "19">
+<!ENTITY STARTHOUR "00">
+
+<!ENTITY ENDYEAR "2019">
+<!ENTITY ENDMONTH "12">
+<!ENTITY ENDDAY "31">
+<!ENTITY ENDHOUR "12">
+
+<!ENTITY USER "Matthew.Pyle">
+<!ENTITY machine "DELL">
+<!ENTITY ACCOUNT "FV3GFS-T2O">
+
+<!ENTITY HOMEfv3 "/gpfs/dell2/emc/modeling/noscrub/&USER;/fv3sar_workflow">
+<!ENTITY domain "conus">
+<!ENTITY JOBS "&HOMEfv3;/jobs">
+<!ENTITY SCRIPTS "&HOMEfv3;/scripts">
+<!ENTITY COMgfs "/gpfs/dell1/nco/ops/com/gfs/prod">
+<!ENTITY COMgfs2 "/gpfs/dell3/ptmp/emc.glopara/ROTDIRS/prfv3rt3/vrfyarch">
+<!ENTITY OUTDIR "/gpfs/dell1/ptmp/&USER;">
+<!ENTITY DATAROOT "/gpfs/dell1/stmp/&USER;/tmpnwprd">
+
+<!ENTITY RESERVATION '<queue>dev</queue><account>&ACCOUNT;</account>'>
+<!ENTITY RESERVATION_TRANSFER '<queue>dev_transfer</queue><account>&ACCOUNT;</account>'>
+
+<!ENTITY CLEANUP_RESOURCES '<walltime>00:10:00</walltime>'>
+<!ENTITY CHGRES_IC_RESOURCES '<walltime>00:15:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY CHGRES_BC_RESOURCES '<walltime>00:12:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY FCST_RESOURCES '<walltime>01:20:00</walltime><native>-R affinity[core\(2\):distribute=balance]</native>'>
+<!ENTITY POST_RESOURCES '<walltime>00:20:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY POSTGOES_RESOURCES '<walltime>00:10:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY HIST_RESOURCES '<walltime>00:30:00</walltime><memory>5G</memory><native>-R affinity[core]</native>'>
+
+]>
+
+
+<!--  ************************************************************* -->
+<!--  ******************* STARTING THE WORKFLOW ******************* -->
+
+<!-- <workflow realtime="F" scheduler="lsf" taskthrottle="11"> -->
+<workflow realtime="T" scheduler="lsf" taskthrottle="60" cyclethrottle="1" cyclelifespan="00:24:00:00">
+
+  <cycledef group="regional">&STARTYEAR;&STARTMONTH;&STARTDAY;&STARTHOUR;00 &ENDYEAR;&ENDMONTH;&ENDDAY;&ENDHOUR;00 12:00:00</cycledef>
+
+  <log>
+    <cyclestr>&OUTDIR;/logfiles_sar/workflow_regional_&domain;_@Y@m@d@H.log</cyclestr>
+  </log>
+
+
+<!--  **********************************************************************  -->
+<!--  **************************** Run chgres ******************************  -->
+
+<!-- Create the initial conditions and boundary condition hour 0 from the FV3GFS -->
+
+  <task name="chgres_firstguess" cycledefs="regional" maxtries="3">
+  &RESERVATION;
+  &CHGRES_IC_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_CHGRES_FIRSTGUESS</command>
+    <jobname><cyclestr>chgres_firstguess_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/chgres_firstguess_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>chgres_firstguess_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+
+    <dependency>
+      <or>
+        <and>
+          <datadep age="10:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf000.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="15779010324"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmanl.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="1170221688"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.sfcanl.nemsio</cyclestr></datadep>
+        </and>
+        <and>
+          <datadep age="10:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf000.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="15779010324"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmanl.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="1170221688"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.sfcanl.nemsio</cyclestr></datadep>
+        </and>
+      </or>
+    </dependency>
+
+  </task>
+
+
+<!-- Create the boundary conditions from the FV3GFS -->
+
+  <task name="chgres_fcstbndy" cycledefs="regional" maxtries="3">
+  &RESERVATION;
+  &CHGRES_BC_RESOURCES;
+  <nodes>20:ppn=1</nodes>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_CHGRES_FCSTBNDY</command>
+    <jobname><cyclestr>chgres_fcstbndy_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/chgres_fcstbndy_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>chgres_fcstbndy_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <or>
+        <and>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf057.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf060.nemsio</cyclestr></datadep>
+        </and>
+        <and>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf009.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf060.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf063.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf066.nemsio</cyclestr></datadep>
+        </and>
+      </or>
+    </dependency>
+
+  </task>
+
+
+<!--  ***********************************************************************  -->
+<!--  ************************* Run the forecast ****************************  -->
+
+  <task name="forecast_tm00" cycledefs="regional" maxtries="1">
+  &RESERVATION;
+  &FCST_RESOURCES;
+  <nodes>114:ppn=12</nodes>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_FCST</command>
+    <jobname><cyclestr>forecast_tm00_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/forecast_tm00_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value><cyclestr>forecast_tm00_&domain;_@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="chgres_firstguess"/>
+        <taskdep task="chgres_fcstbndy"/>
+      </and>
+    </dependency>
+
+  </task>
+
+<!--  *******************************************************************  -->
+<!--  ********************** Run the post processor *********************  -->
+
+  <metatask>
+    <var name="fhr">00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60</var>
+    <task name="post#fhr#" cycledefs="regional" maxtries="2">
+    &RESERVATION;
+    &POST_RESOURCES;
+    <nodes>2:ppn=14</nodes>
+      <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_POST</command>
+      <jobname><cyclestr>fv3_post_&domain;_f#fhr#_@Hz</cyclestr></jobname>
+      <join><cyclestr>&OUTDIR;/logfiles_sar/post_&domain;_f#fhr#_@H_tm00.log</cyclestr></join>
+   
+      <envar>
+        <name>HOMEfv3</name>
+        <value>&HOMEfv3;</value>
+      </envar>
+      <envar>
+        <name>job</name>
+        <value>post_&domain;_f#fhr#</value>
+      </envar>
+      <envar>
+        <name>machine</name>
+        <value>&machine;</value>
+      </envar>
+      <envar>
+        <name>USER</name>
+        <value>&USER;</value>
+      </envar>
+      <envar>
+        <name>CDATE</name>
+        <value><cyclestr>@Y@m@d@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>PDY</name>
+        <value><cyclestr>@Y@m@d</cyclestr></value>
+      </envar>
+      <envar>
+        <name>cyc</name>
+        <value><cyclestr>@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>fhr</name>
+        <value>#fhr#</value>
+      </envar>
+      <envar>
+        <name>tmmark</name>
+        <value>tm00</value>
+      </envar>
+      <envar>
+       <name>dom</name>
+       <value>&domain;</value>
+      </envar>
+
+      <dependency>
+        <and>
+          <datadep age="05:00"><cyclestr>&DATAROOT;/forecast_tm00_&domain;_@Y@m@d_@H/logf0#fhr#</cyclestr></datadep>
+        </and>
+      </dependency>
+    </task>
+  </metatask>
+
+  <metatask name="postgoes" throttle="3">
+    <var name="fhr">00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60</var>
+    <task name="postgoes#fhr#" cycledefs="regional" maxtries="1">
+    &RESERVATION;
+    &POSTGOES_RESOURCES;
+    <nodes>15:ppn=14</nodes>
+      <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_POST_GOES</command>
+      <jobname><cyclestr>fv3_postgoes_&domain;_f#fhr#_@Hz</cyclestr></jobname>
+      <join><cyclestr>&OUTDIR;/logfiles_sar/postgoes_&domain;_f#fhr#_@H_tm00.log</cyclestr></join>
+   
+      <envar>
+        <name>HOMEfv3</name>
+        <value>&HOMEfv3;</value>
+      </envar>
+      <envar>
+        <name>job</name>
+        <value>postgoes_&domain;_f#fhr#</value>
+      </envar>
+      <envar>
+        <name>machine</name>
+        <value>&machine;</value>
+      </envar>
+      <envar>
+        <name>USER</name>
+        <value>&USER;</value>
+      </envar>
+      <envar>
+        <name>CDATE</name>
+        <value><cyclestr>@Y@m@d@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>PDY</name>
+        <value><cyclestr>@Y@m@d</cyclestr></value>
+      </envar>
+      <envar>
+        <name>cyc</name>
+        <value><cyclestr>@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>fhr</name>
+        <value>#fhr#</value>
+      </envar>
+      <envar>
+        <name>tmmark</name>
+        <value>tm00</value>
+      </envar>
+      <envar>
+       <name>dom</name>
+       <value>&domain;</value>
+      </envar>
+
+      <dependency>
+        <and>
+          <datadep age="05:00"><cyclestr>&DATAROOT;/forecast_tm00_&domain;_@Y@m@d_@H/logf0#fhr#</cyclestr></datadep>
+        </and>
+      </dependency>
+    </task>
+  </metatask>
+
+
+<!-- *********************************************************************** -->
+<!-- ***************************** Archive job ***************************** -->
+
+<!--  <task name="rhist" cycledefs="regional" maxtries="2">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_RHIST</command>
+    <jobname><cyclestr>run_history_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/rhist_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value><cyclestr>jrun_history@H_&domain;_fv3sar</cyclestr></value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="post60"/>
+      </and>
+    </dependency>
+  </task> -->
+
+
+<!-- ******************************************************************* -->
+<!-- ************************* FTP transfers *************************** -->
+
+<!--  <task name="sendinibc" cycledefs="regional" maxtries="1">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_SENDINIBC</command>
+    <jobname><cyclestr>sendinibc_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/sendinibc_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>sendinibc_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="chgres_firstguess"/>
+        <taskdep task="chgres_fcstbndy"/>
+      </and>
+    </dependency>
+  </task>
+
+  <task name="sendpost" cycledefs="regional" maxtries="1">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_SENDPOST</command>
+    <jobname><cyclestr>sendpost_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/sendpost_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>sendpost_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="post60"/>
+      </and>
+    </dependency>
+  </task>
+
+  <task name="sendpostgoes" cycledefs="regional" maxtries="1">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_SENDPOST_GOES</command>
+    <jobname><cyclestr>sendpostgoes_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/sendpostgoes_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>sendpostgoes_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="postgoes60"/>
+      </and>
+    </dependency>
+  </task> -->
+
+<!--  **********************************************************************  -->
+<!--  ******************************* Cleanup ******************************  -->
+
+<!--  <task name="cleanup" cycledefs="regional" maxtries="2">
+  &RESERVATION;
+  &CLEANUP_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_CLEANUP</command>
+    <jobname><cyclestr>cleanup_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/cleanup_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>cleanup_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATEm2</name>
+      <value><cyclestr offset="-00:48:00:00">@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="post60"/>
+        <taskdep task="postgoes60"/>
+      </and>
+    </dependency>
+
+  </task> -->
+
+
+</workflow>

--- a/rocoto/drive_fv3sar_guam.xml
+++ b/rocoto/drive_fv3sar_guam.xml
@@ -1,0 +1,639 @@
+<?xml version="1.0"?>
+<!DOCTYPE workflow
+[
+
+<!ENTITY STARTYEAR "2019">
+<!ENTITY STARTMONTH "06">
+<!ENTITY STARTDAY "19">
+<!ENTITY STARTHOUR "00">
+
+<!ENTITY ENDYEAR "2019">
+<!ENTITY ENDMONTH "12">
+<!ENTITY ENDDAY "31">
+<!ENTITY ENDHOUR "12">
+
+<!ENTITY USER "Matthew.Pyle">
+<!ENTITY machine "DELL">
+<!ENTITY ACCOUNT "FV3GFS-T2O">
+
+<!ENTITY HOMEfv3 "/gpfs/dell2/emc/modeling/noscrub/&USER;/fv3sar_workflow">
+<!ENTITY domain "guam">
+<!ENTITY JOBS "&HOMEfv3;/jobs">
+<!ENTITY SCRIPTS "&HOMEfv3;/scripts">
+<!ENTITY COMgfs "/gpfs/dell1/nco/ops/com/gfs/prod">
+<!ENTITY COMgfs2 "/gpfs/dell3/ptmp/emc.glopara/ROTDIRS/prfv3rt3/vrfyarch">
+<!ENTITY OUTDIR "/gpfs/dell1/ptmp/&USER;">
+<!ENTITY DATAROOT "/gpfs/dell1/stmp/&USER;/tmpnwprd">
+
+<!ENTITY RESERVATION '<queue>dev</queue><account>&ACCOUNT;</account>'>
+<!ENTITY RESERVATION_TRANSFER '<queue>dev_transfer</queue><account>&ACCOUNT;</account>'>
+
+<!ENTITY CLEANUP_RESOURCES '<walltime>00:10:00</walltime>'>
+<!ENTITY CHGRES_IC_RESOURCES '<walltime>00:15:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY CHGRES_BC_RESOURCES '<walltime>00:12:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY FCST_RESOURCES '<walltime>01:20:00</walltime><native>-R affinity[core\(2\):distribute=balance]</native>'>
+<!ENTITY POST_RESOURCES '<walltime>00:20:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY POSTGOES_RESOURCES '<walltime>00:10:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY HIST_RESOURCES '<walltime>00:30:00</walltime><memory>5G</memory><native>-R affinity[core]</native>'>
+
+]>
+
+
+<!--  ************************************************************* -->
+<!--  ******************* STARTING THE WORKFLOW ******************* -->
+
+<!-- <workflow realtime="F" scheduler="lsf" taskthrottle="11"> -->
+<workflow realtime="T" scheduler="lsf" taskthrottle="60" cyclethrottle="1" cyclelifespan="00:24:00:00">
+
+  <cycledef group="regional">&STARTYEAR;&STARTMONTH;&STARTDAY;&STARTHOUR;00 &ENDYEAR;&ENDMONTH;&ENDDAY;&ENDHOUR;00 12:00:00</cycledef>
+
+  <log>
+    <cyclestr>&OUTDIR;/logfiles_sar/workflow_regional_&domain;_@Y@m@d@H.log</cyclestr>
+  </log>
+
+
+<!--  **********************************************************************  -->
+<!--  **************************** Run chgres ******************************  -->
+
+<!-- Create the initial conditions and boundary condition hour 0 from the FV3GFS -->
+
+  <task name="chgres_firstguess" cycledefs="regional" maxtries="3">
+  &RESERVATION;
+  &CHGRES_IC_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_CHGRES_FIRSTGUESS</command>
+    <jobname><cyclestr>chgres_firstguess_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/chgres_firstguess_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>chgres_firstguess_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+
+    <dependency>
+      <or>
+        <and>
+          <datadep age="10:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf000.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="15779010324"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmanl.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="1170221688"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.sfcanl.nemsio</cyclestr></datadep>
+        </and>
+        <and>
+          <datadep age="10:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf000.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="15779010324"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmanl.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="1170221688"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.sfcanl.nemsio</cyclestr></datadep>
+        </and>
+      </or>
+    </dependency>
+
+  </task>
+
+
+<!-- Create the boundary conditions from the FV3GFS -->
+
+  <task name="chgres_fcstbndy" cycledefs="regional" maxtries="3">
+  &RESERVATION;
+  &CHGRES_BC_RESOURCES;
+  <nodes>20:ppn=1</nodes>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_CHGRES_FCSTBNDY</command>
+    <jobname><cyclestr>chgres_fcstbndy_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/chgres_fcstbndy_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>chgres_fcstbndy_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <or>
+        <and>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf057.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf060.nemsio</cyclestr></datadep>
+        </and>
+        <and>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf009.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf060.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf063.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf066.nemsio</cyclestr></datadep>
+        </and>
+      </or>
+    </dependency>
+
+  </task>
+
+
+<!--  ***********************************************************************  -->
+<!--  ************************* Run the forecast ****************************  -->
+
+  <task name="forecast_tm00" cycledefs="regional" maxtries="1">
+  &RESERVATION;
+  &FCST_RESOURCES;
+  <nodes>7:ppn=12</nodes>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_FCST</command>
+    <jobname><cyclestr>forecast_tm00_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/forecast_tm00_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value><cyclestr>forecast_tm00_&domain;_@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="chgres_firstguess"/>
+        <taskdep task="chgres_fcstbndy"/>
+      </and>
+    </dependency>
+
+  </task>
+
+<!--  *******************************************************************  -->
+<!--  ********************** Run the post processor *********************  -->
+
+  <metatask>
+    <var name="fhr">00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60</var>
+    <task name="post#fhr#" cycledefs="regional" maxtries="2">
+    &RESERVATION;
+    &POST_RESOURCES;
+    <nodes>1:ppn=14</nodes>
+      <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_POST</command>
+      <jobname><cyclestr>fv3_post_&domain;_f#fhr#_@Hz</cyclestr></jobname>
+      <join><cyclestr>&OUTDIR;/logfiles_sar/post_&domain;_f#fhr#_@H_tm00.log</cyclestr></join>
+   
+      <envar>
+        <name>HOMEfv3</name>
+        <value>&HOMEfv3;</value>
+      </envar>
+      <envar>
+        <name>job</name>
+        <value>post_&domain;_f#fhr#</value>
+      </envar>
+      <envar>
+        <name>machine</name>
+        <value>&machine;</value>
+      </envar>
+      <envar>
+        <name>USER</name>
+        <value>&USER;</value>
+      </envar>
+      <envar>
+        <name>CDATE</name>
+        <value><cyclestr>@Y@m@d@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>PDY</name>
+        <value><cyclestr>@Y@m@d</cyclestr></value>
+      </envar>
+      <envar>
+        <name>cyc</name>
+        <value><cyclestr>@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>fhr</name>
+        <value>#fhr#</value>
+      </envar>
+      <envar>
+        <name>tmmark</name>
+        <value>tm00</value>
+      </envar>
+      <envar>
+       <name>dom</name>
+       <value>&domain;</value>
+      </envar>
+
+      <dependency>
+        <and>
+          <datadep age="05:00"><cyclestr>&DATAROOT;/forecast_tm00_&domain;_@Y@m@d_@H/logf0#fhr#</cyclestr></datadep>
+        </and>
+      </dependency>
+    </task>
+  </metatask>
+
+  <metatask name="postgoes" throttle="12">
+    <var name="fhr">00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60</var>
+    <task name="postgoes#fhr#" cycledefs="regional" maxtries="1">
+    &RESERVATION;
+    &POSTGOES_RESOURCES;
+    <nodes>1:ppn=14</nodes>
+      <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_POST_GOES</command>
+      <jobname><cyclestr>fv3_postgoes_&domain;_f#fhr#_@Hz</cyclestr></jobname>
+      <join><cyclestr>&OUTDIR;/logfiles_sar/postgoes_&domain;_f#fhr#_@H_tm00.log</cyclestr></join>
+   
+      <envar>
+        <name>HOMEfv3</name>
+        <value>&HOMEfv3;</value>
+      </envar>
+      <envar>
+        <name>job</name>
+        <value>postgoes_&domain;_f#fhr#</value>
+      </envar>
+      <envar>
+        <name>machine</name>
+        <value>&machine;</value>
+      </envar>
+      <envar>
+        <name>USER</name>
+        <value>&USER;</value>
+      </envar>
+      <envar>
+        <name>CDATE</name>
+        <value><cyclestr>@Y@m@d@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>PDY</name>
+        <value><cyclestr>@Y@m@d</cyclestr></value>
+      </envar>
+      <envar>
+        <name>cyc</name>
+        <value><cyclestr>@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>fhr</name>
+        <value>#fhr#</value>
+      </envar>
+      <envar>
+        <name>tmmark</name>
+        <value>tm00</value>
+      </envar>
+      <envar>
+       <name>dom</name>
+       <value>&domain;</value>
+      </envar>
+
+      <dependency>
+        <and>
+          <datadep age="05:00"><cyclestr>&DATAROOT;/forecast_tm00_&domain;_@Y@m@d_@H/logf0#fhr#</cyclestr></datadep>
+        </and>
+      </dependency>
+    </task>
+  </metatask>
+
+
+<!-- *********************************************************************** -->
+<!-- ***************************** Archive job ***************************** -->
+
+<!--  <task name="rhist" cycledefs="regional" maxtries="2">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_RHIST</command>
+    <jobname><cyclestr>run_history_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/rhist_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value><cyclestr>jrun_history@H_&domain;_fv3sar</cyclestr></value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="post60"/>
+      </and>
+    </dependency>
+  </task> -->
+
+
+<!-- ******************************************************************* -->
+<!-- ************************* FTP transfers *************************** -->
+
+<!--  <task name="sendinibc" cycledefs="regional" maxtries="1">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_SENDINIBC</command>
+    <jobname><cyclestr>sendinibc_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/sendinibc_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>sendinibc_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="chgres_firstguess"/>
+        <taskdep task="chgres_fcstbndy"/>
+      </and>
+    </dependency>
+  </task>
+
+  <task name="sendpost" cycledefs="regional" maxtries="1">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_SENDPOST</command>
+    <jobname><cyclestr>sendpost_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/sendpost_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>sendpost_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="post60"/>
+      </and>
+    </dependency>
+  </task>
+
+  <task name="sendpostgoes" cycledefs="regional" maxtries="1">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_SENDPOST_GOES</command>
+    <jobname><cyclestr>sendpostgoes_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/sendpostgoes_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>sendpostgoes_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="postgoes60"/>
+      </and>
+    </dependency>
+  </task> -->
+
+<!--  **********************************************************************  -->
+<!--  ******************************* Cleanup ******************************  -->
+
+<!--  <task name="cleanup" cycledefs="regional" maxtries="2">
+  &RESERVATION;
+  &CLEANUP_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_CLEANUP</command>
+    <jobname><cyclestr>cleanup_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/cleanup_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>cleanup_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATEm2</name>
+      <value><cyclestr offset="-00:48:00:00">@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="post60"/>
+        <taskdep task="postgoes60"/>
+      </and>
+    </dependency>
+
+  </task> -->
+
+
+</workflow>

--- a/rocoto/drive_fv3sar_hi.xml
+++ b/rocoto/drive_fv3sar_hi.xml
@@ -1,0 +1,639 @@
+<?xml version="1.0"?>
+<!DOCTYPE workflow
+[
+
+<!ENTITY STARTYEAR "2019">
+<!ENTITY STARTMONTH "06">
+<!ENTITY STARTDAY "19">
+<!ENTITY STARTHOUR "00">
+
+<!ENTITY ENDYEAR "2019">
+<!ENTITY ENDMONTH "12">
+<!ENTITY ENDDAY "31">
+<!ENTITY ENDHOUR "12">
+
+<!ENTITY USER "Matthew.Pyle">
+<!ENTITY machine "DELL">
+<!ENTITY ACCOUNT "FV3GFS-T2O">
+
+<!ENTITY HOMEfv3 "/gpfs/dell2/emc/modeling/noscrub/&USER;/fv3sar_workflow">
+<!ENTITY domain "hi">
+<!ENTITY JOBS "&HOMEfv3;/jobs">
+<!ENTITY SCRIPTS "&HOMEfv3;/scripts">
+<!ENTITY COMgfs "/gpfs/dell1/nco/ops/com/gfs/prod">
+<!ENTITY COMgfs2 "/gpfs/dell3/ptmp/emc.glopara/ROTDIRS/prfv3rt3/vrfyarch">
+<!ENTITY OUTDIR "/gpfs/dell1/ptmp/&USER;">
+<!ENTITY DATAROOT "/gpfs/dell1/stmp/&USER;/tmpnwprd">
+
+<!ENTITY RESERVATION '<queue>dev</queue><account>&ACCOUNT;</account>'>
+<!ENTITY RESERVATION_TRANSFER '<queue>dev_transfer</queue><account>&ACCOUNT;</account>'>
+
+<!ENTITY CLEANUP_RESOURCES '<walltime>00:10:00</walltime>'>
+<!ENTITY CHGRES_IC_RESOURCES '<walltime>00:15:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY CHGRES_BC_RESOURCES '<walltime>00:12:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY FCST_RESOURCES '<walltime>01:20:00</walltime><native>-R affinity[core\(2\):distribute=balance]</native>'>
+<!ENTITY POST_RESOURCES '<walltime>00:20:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY POSTGOES_RESOURCES '<walltime>00:10:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY HIST_RESOURCES '<walltime>00:30:00</walltime><memory>5G</memory><native>-R affinity[core]</native>'>
+
+]>
+
+
+<!--  ************************************************************* -->
+<!--  ******************* STARTING THE WORKFLOW ******************* -->
+
+<!-- <workflow realtime="F" scheduler="lsf" taskthrottle="11"> -->
+<workflow realtime="T" scheduler="lsf" taskthrottle="60" cyclethrottle="1" cyclelifespan="00:24:00:00">
+
+  <cycledef group="regional">&STARTYEAR;&STARTMONTH;&STARTDAY;&STARTHOUR;00 &ENDYEAR;&ENDMONTH;&ENDDAY;&ENDHOUR;00 12:00:00</cycledef>
+
+  <log>
+    <cyclestr>&OUTDIR;/logfiles_sar/workflow_regional_&domain;_@Y@m@d@H.log</cyclestr>
+  </log>
+
+
+<!--  **********************************************************************  -->
+<!--  **************************** Run chgres ******************************  -->
+
+<!-- Create the initial conditions and boundary condition hour 0 from the FV3GFS -->
+
+  <task name="chgres_firstguess" cycledefs="regional" maxtries="3">
+  &RESERVATION;
+  &CHGRES_IC_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_CHGRES_FIRSTGUESS</command>
+    <jobname><cyclestr>chgres_firstguess_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/chgres_firstguess_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>chgres_firstguess_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+
+    <dependency>
+      <or>
+        <and>
+          <datadep age="10:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf000.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="15779010324"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmanl.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="1170221688"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.sfcanl.nemsio</cyclestr></datadep>
+        </and>
+        <and>
+          <datadep age="10:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf000.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="15779010324"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmanl.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="1170221688"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.sfcanl.nemsio</cyclestr></datadep>
+        </and>
+      </or>
+    </dependency>
+
+  </task>
+
+
+<!-- Create the boundary conditions from the FV3GFS -->
+
+  <task name="chgres_fcstbndy" cycledefs="regional" maxtries="3">
+  &RESERVATION;
+  &CHGRES_BC_RESOURCES;
+  <nodes>20:ppn=1</nodes>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_CHGRES_FCSTBNDY</command>
+    <jobname><cyclestr>chgres_fcstbndy_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/chgres_fcstbndy_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>chgres_fcstbndy_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <or>
+        <and>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf057.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf060.nemsio</cyclestr></datadep>
+        </and>
+        <and>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf009.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf060.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf063.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf066.nemsio</cyclestr></datadep>
+        </and>
+      </or>
+    </dependency>
+
+  </task>
+
+
+<!--  ***********************************************************************  -->
+<!--  ************************* Run the forecast ****************************  -->
+
+  <task name="forecast_tm00" cycledefs="regional" maxtries="1">
+  &RESERVATION;
+  &FCST_RESOURCES;
+  <nodes>7:ppn=12</nodes>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_FCST</command>
+    <jobname><cyclestr>forecast_tm00_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/forecast_tm00_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value><cyclestr>forecast_tm00_&domain;_@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="chgres_firstguess"/>
+        <taskdep task="chgres_fcstbndy"/>
+      </and>
+    </dependency>
+
+  </task>
+
+<!--  *******************************************************************  -->
+<!--  ********************** Run the post processor *********************  -->
+
+  <metatask>
+    <var name="fhr">00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60</var>
+    <task name="post#fhr#" cycledefs="regional" maxtries="2">
+    &RESERVATION;
+    &POST_RESOURCES;
+    <nodes>1:ppn=14</nodes>
+      <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_POST</command>
+      <jobname><cyclestr>fv3_post_&domain;_f#fhr#_@Hz</cyclestr></jobname>
+      <join><cyclestr>&OUTDIR;/logfiles_sar/post_&domain;_f#fhr#_@H_tm00.log</cyclestr></join>
+   
+      <envar>
+        <name>HOMEfv3</name>
+        <value>&HOMEfv3;</value>
+      </envar>
+      <envar>
+        <name>job</name>
+        <value>post_&domain;_f#fhr#</value>
+      </envar>
+      <envar>
+        <name>machine</name>
+        <value>&machine;</value>
+      </envar>
+      <envar>
+        <name>USER</name>
+        <value>&USER;</value>
+      </envar>
+      <envar>
+        <name>CDATE</name>
+        <value><cyclestr>@Y@m@d@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>PDY</name>
+        <value><cyclestr>@Y@m@d</cyclestr></value>
+      </envar>
+      <envar>
+        <name>cyc</name>
+        <value><cyclestr>@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>fhr</name>
+        <value>#fhr#</value>
+      </envar>
+      <envar>
+        <name>tmmark</name>
+        <value>tm00</value>
+      </envar>
+      <envar>
+       <name>dom</name>
+       <value>&domain;</value>
+      </envar>
+
+      <dependency>
+        <and>
+          <datadep age="03:00"><cyclestr>&DATAROOT;/forecast_tm00_&domain;_@Y@m@d_@H/logf0#fhr#</cyclestr></datadep>
+        </and>
+      </dependency>
+    </task>
+  </metatask>
+
+  <metatask name="postgoes" throttle="12">
+    <var name="fhr">00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60</var>
+    <task name="postgoes#fhr#" cycledefs="regional" maxtries="1">
+    &RESERVATION;
+    &POSTGOES_RESOURCES;
+    <nodes>1:ppn=14</nodes>
+      <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_POST_GOES</command>
+      <jobname><cyclestr>fv3_postgoes_&domain;_f#fhr#_@Hz</cyclestr></jobname>
+      <join><cyclestr>&OUTDIR;/logfiles_sar/postgoes_&domain;_f#fhr#_@H_tm00.log</cyclestr></join>
+   
+      <envar>
+        <name>HOMEfv3</name>
+        <value>&HOMEfv3;</value>
+      </envar>
+      <envar>
+        <name>job</name>
+        <value>postgoes_&domain;_f#fhr#</value>
+      </envar>
+      <envar>
+        <name>machine</name>
+        <value>&machine;</value>
+      </envar>
+      <envar>
+        <name>USER</name>
+        <value>&USER;</value>
+      </envar>
+      <envar>
+        <name>CDATE</name>
+        <value><cyclestr>@Y@m@d@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>PDY</name>
+        <value><cyclestr>@Y@m@d</cyclestr></value>
+      </envar>
+      <envar>
+        <name>cyc</name>
+        <value><cyclestr>@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>fhr</name>
+        <value>#fhr#</value>
+      </envar>
+      <envar>
+        <name>tmmark</name>
+        <value>tm00</value>
+      </envar>
+      <envar>
+       <name>dom</name>
+       <value>&domain;</value>
+      </envar>
+
+      <dependency>
+        <and>
+          <datadep age="03:00"><cyclestr>&DATAROOT;/forecast_tm00_&domain;_@Y@m@d_@H/logf0#fhr#</cyclestr></datadep>
+        </and>
+      </dependency>
+    </task>
+  </metatask>
+
+
+<!-- *********************************************************************** -->
+<!-- ***************************** Archive job ***************************** -->
+
+<!--  <task name="rhist" cycledefs="regional" maxtries="2">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_RHIST</command>
+    <jobname><cyclestr>run_history_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/rhist_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value><cyclestr>jrun_history@H_&domain;_fv3sar</cyclestr></value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="post60"/>
+      </and>
+    </dependency>
+  </task> -->
+
+
+<!-- ******************************************************************* -->
+<!-- ************************* FTP transfers *************************** -->
+
+<!--  <task name="sendinibc" cycledefs="regional" maxtries="1">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_SENDINIBC</command>
+    <jobname><cyclestr>sendinibc_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/sendinibc_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>sendinibc_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="chgres_firstguess"/>
+        <taskdep task="chgres_fcstbndy"/>
+      </and>
+    </dependency>
+  </task>
+
+  <task name="sendpost" cycledefs="regional" maxtries="1">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_SENDPOST</command>
+    <jobname><cyclestr>sendpost_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/sendpost_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>sendpost_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="post60"/>
+      </and>
+    </dependency>
+  </task>
+
+  <task name="sendpostgoes" cycledefs="regional" maxtries="1">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_SENDPOST_GOES</command>
+    <jobname><cyclestr>sendpostgoes_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/sendpostgoes_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>sendpostgoes_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="postgoes60"/>
+      </and>
+    </dependency>
+  </task> -->
+
+<!--  **********************************************************************  -->
+<!--  ******************************* Cleanup ******************************  -->
+
+<!--  <task name="cleanup" cycledefs="regional" maxtries="2">
+  &RESERVATION;
+  &CLEANUP_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_CLEANUP</command>
+    <jobname><cyclestr>cleanup_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/cleanup_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>cleanup_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATEm2</name>
+      <value><cyclestr offset="-00:48:00:00">@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="post60"/>
+        <taskdep task="postgoes60"/>
+      </and>
+    </dependency>
+
+  </task> -->
+
+
+</workflow>

--- a/rocoto/drive_fv3sar_pr.xml
+++ b/rocoto/drive_fv3sar_pr.xml
@@ -1,0 +1,639 @@
+<?xml version="1.0"?>
+<!DOCTYPE workflow
+[
+
+<!ENTITY STARTYEAR "2019">
+<!ENTITY STARTMONTH "06">
+<!ENTITY STARTDAY "19">
+<!ENTITY STARTHOUR "06">
+
+<!ENTITY ENDYEAR "2020">
+<!ENTITY ENDMONTH "12">
+<!ENTITY ENDDAY "31">
+<!ENTITY ENDHOUR "18">
+
+<!ENTITY USER "Matthew.Pyle">
+<!ENTITY machine "DELL">
+<!ENTITY ACCOUNT "FV3GFS-T2O">
+
+<!ENTITY HOMEfv3 "/gpfs/dell2/emc/modeling/noscrub/&USER;/fv3sar_workflow">
+<!ENTITY domain "pr">
+<!ENTITY JOBS "&HOMEfv3;/jobs">
+<!ENTITY SCRIPTS "&HOMEfv3;/scripts">
+<!ENTITY COMgfs "/gpfs/dell1/nco/ops/com/gfs/prod">
+<!ENTITY COMgfs2 "/gpfs/dell3/ptmp/emc.glopara/ROTDIRS/prfv3rt3/vrfyarch">
+<!ENTITY OUTDIR "/gpfs/dell1/ptmp/&USER;">
+<!ENTITY DATAROOT "/gpfs/dell1/stmp/&USER;/tmpnwprd">
+
+<!ENTITY RESERVATION '<queue>dev</queue><account>&ACCOUNT;</account>'>
+<!ENTITY RESERVATION_TRANSFER '<queue>dev_transfer</queue><account>&ACCOUNT;</account>'>
+
+<!ENTITY CLEANUP_RESOURCES '<walltime>00:10:00</walltime>'>
+<!ENTITY CHGRES_IC_RESOURCES '<walltime>00:15:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY CHGRES_BC_RESOURCES '<walltime>00:12:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY FCST_RESOURCES '<walltime>01:20:00</walltime><native>-R affinity[core\(2\):distribute=balance]</native>'>
+<!ENTITY POST_RESOURCES '<walltime>00:20:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY POSTGOES_RESOURCES '<walltime>00:10:00</walltime><native>-R affinity[core]</native>'>
+<!ENTITY HIST_RESOURCES '<walltime>00:30:00</walltime><memory>5G</memory><native>-R affinity[core]</native>'>
+
+]>
+
+
+<!--  ************************************************************* -->
+<!--  ******************* STARTING THE WORKFLOW ******************* -->
+
+<!-- <workflow realtime="F" scheduler="lsf" taskthrottle="11"> -->
+<workflow realtime="T" scheduler="lsf" taskthrottle="60" cyclethrottle="1" cyclelifespan="00:24:00:00">
+
+  <cycledef group="regional">&STARTYEAR;&STARTMONTH;&STARTDAY;&STARTHOUR;00 &ENDYEAR;&ENDMONTH;&ENDDAY;&ENDHOUR;00 12:00:00</cycledef>
+
+  <log>
+    <cyclestr>&OUTDIR;/logfiles_sar/workflow_regional_&domain;_@Y@m@d@H.log</cyclestr>
+  </log>
+
+
+<!--  **********************************************************************  -->
+<!--  **************************** Run chgres ******************************  -->
+
+<!-- Create the initial conditions and boundary condition hour 0 from the FV3GFS -->
+
+  <task name="chgres_firstguess" cycledefs="regional" maxtries="3">
+  &RESERVATION;
+  &CHGRES_IC_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_CHGRES_FIRSTGUESS</command>
+    <jobname><cyclestr>chgres_firstguess_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/chgres_firstguess_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>chgres_firstguess_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+
+    <dependency>
+      <or>
+        <and>
+          <datadep age="10:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf000.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="15779010324"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmanl.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="1170221688"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.sfcanl.nemsio</cyclestr></datadep>
+        </and>
+        <and>
+          <datadep age="10:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf000.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="15779010324"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmanl.nemsio</cyclestr></datadep>
+          <datadep age="10:00" minsize="1170221688"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.sfcanl.nemsio</cyclestr></datadep>
+        </and>
+      </or>
+    </dependency>
+
+  </task>
+
+
+<!-- Create the boundary conditions from the FV3GFS -->
+
+  <task name="chgres_fcstbndy" cycledefs="regional" maxtries="3">
+  &RESERVATION;
+  &CHGRES_BC_RESOURCES;
+  <nodes>20:ppn=1</nodes>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_CHGRES_FCSTBNDY</command>
+    <jobname><cyclestr>chgres_fcstbndy_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/chgres_fcstbndy_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>chgres_fcstbndy_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <or>
+        <and>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf057.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf060.nemsio</cyclestr></datadep>
+        </and>
+        <and>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf009.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf060.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf063.nemsio</cyclestr></datadep>
+          <datadep age="05:00" minsize="16986972692"><cyclestr>&COMgfs2;/gfs.@Y@m@d/@H/gfs.t@Hz.atmf066.nemsio</cyclestr></datadep>
+        </and>
+      </or>
+    </dependency>
+
+  </task>
+
+
+<!--  ***********************************************************************  -->
+<!--  ************************* Run the forecast ****************************  -->
+
+  <task name="forecast_tm00" cycledefs="regional" maxtries="1">
+  &RESERVATION;
+  &FCST_RESOURCES;
+  <nodes>10:ppn=12</nodes>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_FCST</command>
+    <jobname><cyclestr>forecast_tm00_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/forecast_tm00_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value><cyclestr>forecast_tm00_&domain;_@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="chgres_firstguess"/>
+        <taskdep task="chgres_fcstbndy"/>
+      </and>
+    </dependency>
+
+  </task>
+
+<!--  *******************************************************************  -->
+<!--  ********************** Run the post processor *********************  -->
+
+  <metatask>
+    <var name="fhr">00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60</var>
+    <task name="post#fhr#" cycledefs="regional" maxtries="2">
+    &RESERVATION;
+    &POST_RESOURCES;
+    <nodes>1:ppn=14</nodes>
+      <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_POST</command>
+      <jobname><cyclestr>fv3_post_&domain;_f#fhr#_@Hz</cyclestr></jobname>
+      <join><cyclestr>&OUTDIR;/logfiles_sar/post_&domain;_f#fhr#_@H_tm00.log</cyclestr></join>
+   
+      <envar>
+        <name>HOMEfv3</name>
+        <value>&HOMEfv3;</value>
+      </envar>
+      <envar>
+        <name>job</name>
+        <value>post_&domain;_f#fhr#</value>
+      </envar>
+      <envar>
+        <name>machine</name>
+        <value>&machine;</value>
+      </envar>
+      <envar>
+        <name>USER</name>
+        <value>&USER;</value>
+      </envar>
+      <envar>
+        <name>CDATE</name>
+        <value><cyclestr>@Y@m@d@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>PDY</name>
+        <value><cyclestr>@Y@m@d</cyclestr></value>
+      </envar>
+      <envar>
+        <name>cyc</name>
+        <value><cyclestr>@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>fhr</name>
+        <value>#fhr#</value>
+      </envar>
+      <envar>
+        <name>tmmark</name>
+        <value>tm00</value>
+      </envar>
+      <envar>
+       <name>dom</name>
+       <value>&domain;</value>
+      </envar>
+
+      <dependency>
+        <and>
+          <datadep age="03:00"><cyclestr>&DATAROOT;/forecast_tm00_&domain;_@Y@m@d_@H/logf0#fhr#</cyclestr></datadep>
+        </and>
+      </dependency>
+    </task>
+  </metatask>
+
+  <metatask name="postgoes" throttle="9">
+    <var name="fhr">00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60</var>
+    <task name="postgoes#fhr#" cycledefs="regional" maxtries="1">
+    &RESERVATION;
+    &POSTGOES_RESOURCES;
+    <nodes>1:ppn=14</nodes>
+      <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_POST_GOES</command>
+      <jobname><cyclestr>fv3_postgoes_&domain;_f#fhr#_@Hz</cyclestr></jobname>
+      <join><cyclestr>&OUTDIR;/logfiles_sar/postgoes_&domain;_f#fhr#_@H_tm00.log</cyclestr></join>
+   
+      <envar>
+        <name>HOMEfv3</name>
+        <value>&HOMEfv3;</value>
+      </envar>
+      <envar>
+        <name>job</name>
+        <value>postgoes_&domain;_f#fhr#</value>
+      </envar>
+      <envar>
+        <name>machine</name>
+        <value>&machine;</value>
+      </envar>
+      <envar>
+        <name>USER</name>
+        <value>&USER;</value>
+      </envar>
+      <envar>
+        <name>CDATE</name>
+        <value><cyclestr>@Y@m@d@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>PDY</name>
+        <value><cyclestr>@Y@m@d</cyclestr></value>
+      </envar>
+      <envar>
+        <name>cyc</name>
+        <value><cyclestr>@H</cyclestr></value>
+      </envar>
+      <envar>
+        <name>fhr</name>
+        <value>#fhr#</value>
+      </envar>
+      <envar>
+        <name>tmmark</name>
+        <value>tm00</value>
+      </envar>
+      <envar>
+       <name>dom</name>
+       <value>&domain;</value>
+      </envar>
+
+      <dependency>
+        <and>
+          <datadep age="03:00"><cyclestr>&DATAROOT;/forecast_tm00_&domain;_@Y@m@d_@H/logf0#fhr#</cyclestr></datadep>
+        </and>
+      </dependency>
+    </task>
+  </metatask>
+
+
+<!-- *********************************************************************** -->
+<!-- ***************************** Archive job ***************************** -->
+
+<!--  <task name="rhist" cycledefs="regional" maxtries="2">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_RHIST</command>
+    <jobname><cyclestr>run_history_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/rhist_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value><cyclestr>jrun_history@H_&domain;_fv3sar</cyclestr></value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="post60"/>
+      </and>
+    </dependency>
+  </task> -->
+
+
+<!-- ******************************************************************* -->
+<!-- ************************* FTP transfers *************************** -->
+
+<!--  <task name="sendinibc" cycledefs="regional" maxtries="1">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_SENDINIBC</command>
+    <jobname><cyclestr>sendinibc_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/sendinibc_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>sendinibc_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="chgres_firstguess"/>
+        <taskdep task="chgres_fcstbndy"/>
+      </and>
+    </dependency>
+  </task>
+
+  <task name="sendpost" cycledefs="regional" maxtries="1">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_SENDPOST</command>
+    <jobname><cyclestr>sendpost_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/sendpost_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>sendpost_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="post60"/>
+      </and>
+    </dependency>
+  </task>
+
+  <task name="sendpostgoes" cycledefs="regional" maxtries="1">
+  &RESERVATION_TRANSFER;
+  &HIST_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_SENDPOST_GOES</command>
+    <jobname><cyclestr>sendpostgoes_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/sendpostgoes_&domain;_@H.log</cyclestr></join>  
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>sendpostgoes_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATE</name>
+      <value><cyclestr>@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>tmmark</name>
+      <value>tm00</value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="postgoes60"/>
+      </and>
+    </dependency>
+  </task> -->
+
+<!--  **********************************************************************  -->
+<!--  ******************************* Cleanup ******************************  -->
+
+<!--  <task name="cleanup" cycledefs="regional" maxtries="2">
+  &RESERVATION;
+  &CLEANUP_RESOURCES;
+  <cores>1</cores>
+    <command>&JOBS;/launch.ksh &JOBS;/JFV3CAM_SAR_CLEANUP</command>
+    <jobname><cyclestr>cleanup_&domain;_@H</cyclestr></jobname>
+    <join><cyclestr>&OUTDIR;/logfiles_sar/cleanup_&domain;_@H.log</cyclestr></join>
+
+    <envar>
+      <name>HOMEfv3</name>
+      <value>&HOMEfv3;</value>
+    </envar>
+    <envar>
+      <name>job</name>
+      <value>cleanup_&domain;</value>
+    </envar>
+    <envar>
+      <name>machine</name>
+      <value>&machine;</value>
+    </envar>
+    <envar>
+      <name>USER</name>
+      <value>&USER;</value>
+    </envar>
+    <envar>
+      <name>CDATEm2</name>
+      <value><cyclestr offset="-00:48:00:00">@Y@m@d@H</cyclestr></value>
+    </envar>
+    <envar>
+      <name>PDY</name>
+      <value><cyclestr>@Y@m@d</cyclestr></value>
+    </envar>
+    <envar>
+      <name>cyc</name>
+      <value><cyclestr>@H</cyclestr></value>
+    </envar>
+    <envar>
+     <name>dom</name>
+     <value>&domain;</value>
+    </envar>
+
+    <dependency>
+      <and>
+        <taskdep task="post60"/>
+        <taskdep task="postgoes60"/>
+      </and>
+    </dependency>
+
+  </task> -->
+
+
+</workflow>

--- a/rocoto/run_fv3sar_multi.sh
+++ b/rocoto/run_fv3sar_multi.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -l
+set +x
+. /usrx/local/prod/lmod/lmod/init/sh
+set -x
+
+module load impi/18.0.1
+module load lsf/10.1
+
+module use /gpfs/dell3/usrx/local/dev/emc_rocoto/modulefiles/
+module load ruby/2.5.1 rocoto/1.2.4
+
+doms="hi pr"
+
+
+dir="/gpfs/dell2/emc/modeling/noscrub/${USER}/fv3sar_workflow_mybranch/rocoto"
+
+for dom in $doms
+do
+rocotorun -v 10 -w ${dir}/drive_fv3sar_${dom}.xml -d ${dir}/drive_fv3sar_${dom}.db
+sleep 60
+done

--- a/scripts/exfv3cam_post.sh
+++ b/scripts/exfv3cam_post.sh
@@ -52,8 +52,25 @@ mpirun ${POSTGPEXEC} < itag > $pgmout 2> err
 export err=$?; err_chk
 
 # Run wgrib2
-domain=conus
+domain=${dom}
+
+if [ $domain = conus ]
+then
 gridspecs="lambert:262.5:38.5:38.5 237.280:1799:3000 21.138:1059:3000"
+elif [ $domain = "ak" ]
+then
+gridspecs="nps:210:60 185.5:825:5000 44.8:603:5000"
+elif [ $domain = pr ]
+then
+gridspecs="latlon 283.41:340:.045 13.5:208:.045"
+elif [ $domain = hi  ]
+then
+gridspecs="latlon 197.65:223:.045 16.4:170:.045"
+elif [ $domain = guam  ]
+then
+gridspecs="latlon 141.0:223:.045 11.7:170:.045"
+fi
+
 compress_type=c3
 
 if [ $fhr -eq 00 ] ; then

--- a/scripts/exfv3cam_post_goes.sh
+++ b/scripts/exfv3cam_post_goes.sh
@@ -74,15 +74,32 @@ mpirun ${POSTGPEXEC} < itag > $pgmout 2>err
 export err=$?; err_chk
 
 # RUN wgrib2
-domain=conus
+domain=${dom}
+
+if [ $domain = "conus" ]
+then
 gridspecs="lambert:262.5:38.5:38.5 237.280:1799:3000 21.138:1059:3000"
+elif [ $domain = "ak" ]
+then
+gridspecs="nps:210:60 185.5:825:5000 44.8:603:5000"
+elif [ $domain = "pr" ]
+then
+gridspecs="latlon 283.41:340:.045 13.5:208:.045"
+elif [ $domain = "hi" ]
+then
+gridspecs="latlon 197.65:223:.045 16.4:170:.045"
+elif [ $domain = guam  ]
+then
+gridspecs="latlon 141.0:223:.045 11.7:170:.045"
+fi
+
 compress_type=c3
 
 $WGRIB2 BGGOES${fhr}.${tmmark} -set_bitmap 1 -set_grib_type ${compress_type} -new_grid_winds grid -new_grid_vectors "UGRD:VGRD:USTM:VSTM" \
      -new_grid_interpolation neighbor \
      -new_grid ${gridspecs} ${domain}fv3.goestb${fhr}.${tmmark}
 
-mv ${domain}fv3.goestb${fhr}.${tmmark} $COMOUT/${RUN}.t${cyc}z.conusgoestb.f${fhr}.grib2
+mv ${domain}fv3.goestb${fhr}.${tmmark} $COMOUT/${RUN}.t${cyc}z.${dom}goestb.f${fhr}.grib2
 
 echo done > ${INPUT_DATA}/postgoestbdone${fhr}.${tmmark}
 

--- a/scripts/exfv3cam_sar_fcst.sh
+++ b/scripts/exfv3cam_sar_fcst.sh
@@ -117,7 +117,7 @@ if [ $tmmark = tm00 ] ; then
 
 if [ $dom = "conus" ]
 then
-  nodes=114  
+  nodes=76 
 elif [ $dom = "ak" ]
 then
   nodes=68

--- a/scripts/exfv3cam_sar_fcst.sh
+++ b/scripts/exfv3cam_sar_fcst.sh
@@ -19,7 +19,7 @@ ulimit -s unlimited
 ulimit -a
 
 mkdir -p INPUT RESTART
-cp ${NWGES}/anl.${tmmark}/*.nc INPUT
+cp ${NWGES}/anl.${dom}.${tmmark}/*.nc INPUT
 
 numbndy=`ls -l INPUT/gfs_bndy.tile7*.nc | wc -l`
 let "numbndy_check=$NHRS/3+1"
@@ -102,20 +102,41 @@ cd ..
 #   input.nml, input_nest02.nml, model_configure, and nems.configure
 #-------------------------------------------------------------------
 
+
+echo in fcst script we know that dom is $dom
+
 if [ $tmmark = tm00 ] ; then
 # Free forecast with DA (warm start)
   if [ $model = fv3sar_da ] ; then
     cp ${PARMfv3}/input_sar_da.nml input.nml 
 # Free forecast without DA (cold start)
   elif [ $model = fv3sar ] ; then 
-    cp ${PARMfv3}/input_sar.nml input.nml
+    cp ${PARMfv3}/input_sar_${dom}.nml input.nml
   fi
-  cp ${PARMfv3}/model_configure_sar.tmp model_configure.tmp
-  nodes=76  
-  ncnode=24
-  let nctsk=ncnode/OMP_NUM_THREADS    # 12 tasks per node with 2 threads 
-  let ntasks=nodes*nctsk
-  echo nctsk = $nctsk and ntasks = $ntasks
+  cp ${PARMfv3}/model_configure_sar.tmp_${dom} model_configure.tmp
+
+if [ $dom = "conus" ]
+then
+  nodes=114  
+elif [ $dom = "ak" ]
+then
+  nodes=68
+elif [ $dom = "pr" ]
+then
+  nodes=10
+elif [ $dom = "hi" ]
+then
+  nodes=7
+elif [ $dom = "guam" ]
+then
+  nodes=7
+fi
+
+ncnode=24
+let nctsk=ncnode/OMP_NUM_THREADS    # 12 tasks per node with 2 threads 
+let ntasks=nodes*nctsk
+echo nctsk = $nctsk and ntasks = $ntasks
+
 # Submit post manager here
 
 else


### PR DESCRIPTION
Limited work to the SAR configuration, and primarily added unique rocoto scripts and parm files for each of the domains needed for HREFv3.  Changes were intended to be backward compatible (using the old driver script wasn't intentionally broken), but this was not tested.  

Added subdirectories to the emc.campara fix_sar directory for the separate domains (conus domain currently both in main directory and in the conus sub-directory).  