### PR TITLE
Pointed to the regional branch for both GSI and POST to support Odin …

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -13,14 +13,14 @@ local_path = sorc/regional_forecast.fd
 required = True
 
 [gsi]
-branch = master
+branch = regional
 protocol = git
 repo_url = gerrit:ProdGSI
 local_path = sorc/regional_gsi.fd
 required = True
 
 [post]
-branch = master
+branch = regional
 protocol = git
 repo_url = gerrit:EMC_post
 local_path = sorc/regional_post.fd


### PR DESCRIPTION
Changed one file, _Externals.cfg_ that replaces branch "master" for GSI and POST with "regional" to support Odin at NSSL. 