### PR TITLE
Fix to forecast run script and remove fixed paths from chgres ush script

### DIFF
--- a/scripts/exfv3cam_sar_fcst.sh
+++ b/scripts/exfv3cam_sar_fcst.sh
@@ -176,8 +176,8 @@ else
 fi
 
 cat > temp << !
-${yr}${mn}${dy}.${cyc}Z.${CASE}.32bit.non-hydro
-$yr $mn $dy $cyc 0 0
+${yr}${mn}${dy}.${hr}Z.${CASE}.32bit.non-hydro
+$yr $mn $dy $hr 0 0
 !
 
 cat temp diag_table.tmp > diag_table

--- a/ush/global_chgres.sh
+++ b/ush/global_chgres.sh
@@ -260,10 +260,6 @@ gfs_ver=${gfs_ver:-v15.0.0}
 BASEDIR=${BASEDIR:-${NWROOT:-/nwprod2}}
 HOMEgfs=${HOMEgfs:-$BASEDIR/gfs.${gfs_ver}}
 EXECgfs=${EXECgfs:-$HOMEgfs/exec}
-FIXfv3=${FIXfv3:-/gpfs/dell2/emc/modeling/noscrub/${USER}/regional_workflow/fix}
-FIXsar=${FIXsar:-$FIXfv3/fix_sar}
-FIXnest=${FIXnest:-$FIXfv3/fix_nest}
-FIXam=${FIXam:-$FIXfv3/fix_am}
 
 DATA=${DATA:-$(pwd)}
 #  Filenames.


### PR DESCRIPTION
Eric R found a typo in the forecast run script.  Also, there were paths to fix files defined in the ush/global_chgres.sh script which should not be there.