### PR TITLE
- Modify Externals.cfg to use head of NCAR/UFS_UTILS dtc/develop branch

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,8 +1,7 @@
 [ufs_utils_develop]
+branch = dtc/develop
 protocol = git
 repo_url = https://github.com/NCAR/UFS_UTILS
-#Working hash of develop branch
-hash = 4643e2c
 local_path = sorc/UFS_UTILS_develop
 required = True
 

--- a/modulefiles/regional_workflow/global_equiv_resol.cheyenne
+++ b/modulefiles/regional_workflow/global_equiv_resol.cheyenne
@@ -1,0 +1,10 @@
+#%Module#####################################################
+## Module file for regional_grid
+#############################################################
+module purge
+module load ncarenv/1.3
+module load intel/18.0.5
+module load ncarcompilers/0.5.0
+module load netcdf/4.6.3
+# No hdf5 loaded since netcdf and hdf5 reside together on cheyenne
+

--- a/modulefiles/regional_workflow/mosaic_file.cheyenne
+++ b/modulefiles/regional_workflow/mosaic_file.cheyenne
@@ -1,0 +1,10 @@
+#%Module#####################################################
+## Module file for regional_grid
+#############################################################
+module purge
+module load ncarenv/1.3
+module load intel/18.0.5
+module load ncarcompilers/0.5.0
+module load impi/2018.4.274
+module load netcdf/4.6.3
+# No hdf5 loaded since netcdf and hdf5 reside together on cheyenne

--- a/modulefiles/regional_workflow/regional_grid.cheyenne
+++ b/modulefiles/regional_workflow/regional_grid.cheyenne
@@ -1,0 +1,10 @@
+#%Module#####################################################
+## Module file for regional_grid
+#############################################################
+module purge
+module load ncarenv/1.3
+module load intel/18.0.5
+module load ncarcompilers/0.5.0
+module load impi/2018.4.274
+module load netcdf/4.6.3
+# No hdf5 loaded since netcdf and hdf5 reside together on cheyenne

--- a/sorc/build_global_equiv_resol.sh
+++ b/sorc/build_global_equiv_resol.sh
@@ -68,6 +68,7 @@ elif [ $platform = "hera" ]; then
 elif [ $platform = "cheyenne" ]; then
   NETCDF_DIR=$NETCDF
   HDF5_DIR=$NETCDF #HDF5 resides with NETCDF on Cheyenne
+  export HDF5=$NETCDF     #HDF5 used in Makefile_cheyenne
 elif [ $platform = "jet" ]; then
   HDF5_DIR=$HDF5
   NETCDF_DIR=$NETCDF4

--- a/sorc/build_mosaic_file.sh
+++ b/sorc/build_mosaic_file.sh
@@ -68,6 +68,7 @@ elif [ $platform = "hera" ]; then
 elif [ $platform = "cheyenne" ]; then
   NETCDF_DIR=$NETCDF
   HDF5_DIR=$NETCDF #HDF5 resides with NETCDF on Cheyenne
+  export HDF5=$NETCDF     #HDF5 used in Makefile_cheyenne
 elif [ $platform = "jet" ]; then
   HDF5_DIR=$HDF5
   NETCDF_DIR=$NETCDF4

--- a/sorc/build_regional_grid.sh
+++ b/sorc/build_regional_grid.sh
@@ -68,6 +68,7 @@ elif [ $platform = "hera" ]; then
 elif [ $platform = "cheyenne" ]; then
   NETCDF_DIR=$NETCDF
   HDF5_DIR=$NETCDF #HDF5 resides with NETCDF on Cheyenne
+  export HDF5=$NETCDF     #HDF5 used in Makefile_cheyenne
 elif [ $platform = "jet" ]; then
   HDF5_DIR=$HDF5
   NETCDF_DIR=$NETCDF

--- a/sorc/global_equiv_resol.fd/Makefile_cheyenne
+++ b/sorc/global_equiv_resol.fd/Makefile_cheyenne
@@ -1,0 +1,29 @@
+SHELL := bash
+
+MAKEFLAGS += --warn-undefined-variables
+
+INC  = -I${NETCDF}/include
+
+LIBS = ${NETCDF}/lib/libnetcdff.a ${NETCDF}/lib/libnetcdf.a \
+       ${HDF5}/lib/libhdf5_hl.a ${HDF5}/lib/libhdf5.a ${NETCDF}/lib/libsz.a -lz
+
+FC = ifort
+FFLAGS = -g -O2 $(INC)
+
+EXEC = global_equiv_resol
+
+.PHONY: all
+all : $(EXEC)
+
+$(EXEC): global_equiv_resol.o $(LIBS)
+	$(FC) $(FFLAGS) -o $@ $^
+
+.SUFFIXES:
+.SUFFIXES: .f90 .o
+
+.f90.o:
+	$(FC) $(FFLAGS) -c $<
+
+.PHONY: clean
+clean:
+	rm -f *.o *.mod $(EXEC)

--- a/sorc/mosaic_file.fd/Makefile_cheyenne
+++ b/sorc/mosaic_file.fd/Makefile_cheyenne
@@ -1,0 +1,29 @@
+SHELL := bash
+
+MAKEFLAGS += --warn-undefined-variables
+
+INC  = -I${NETCDF}/include
+
+LIBS = ${NETCDF}/lib/libnetcdff.a ${NETCDF}/lib/libnetcdf.a \
+       ${HDF5}/lib/libhdf5_hl.a ${HDF5}/lib/libhdf5.a ${NETCDF}/lib/libsz.a -lz
+
+FC = ifort
+FFLAGS = -g -O2 $(INC)
+
+EXEC = mosaic_file
+
+.PHONY: all
+all : $(EXEC)
+
+$(EXEC): mosaic_file.o $(LIBS)
+	$(FC) $(FFLAGS) -o $@ $^
+
+.SUFFIXES:
+.SUFFIXES: .f90 .o
+
+.f90.o:
+	$(FC) $(FFLAGS) -c $<
+
+.PHONY: clean
+clean:
+	rm -f *.o *.mod $(EXEC)

--- a/sorc/regional_grid.fd/Makefile_cheyenne
+++ b/sorc/regional_grid.fd/Makefile_cheyenne
@@ -1,0 +1,29 @@
+SHELL := bash
+
+MAKEFLAGS += --warn-undefined-variables
+
+INC  = -I${NETCDF}/include
+
+LIBS = ${NETCDF}/lib/libnetcdff.a ${NETCDF}/lib/libnetcdf.a \
+       ${HDF5}/lib/libhdf5_hl.a ${HDF5}/lib/libhdf5.a ${NETCDF}/lib/libsz.a -lz
+
+FC = ifort
+FFLAGS = -g -O2 $(INC)
+
+REGIONAL_GRID = regional_grid
+
+.PHONY: all
+all : $(REGIONAL_GRID)
+
+$(REGIONAL_GRID): pkind.o pietc.o pmat.o pmat4.o pmat5.o psym2.o gen_schmidt.o hgrid_ak.o regional_grid.o $(LIBS)
+	$(FC) $(FFLAGS) -o $@ $^
+
+.SUFFIXES:
+.SUFFIXES: .f90 .o
+
+.f90.o:
+	$(FC) $(FFLAGS) -c $<
+
+.PHONY: clean
+clean:
+	rm -f *.o *.mod $(REGIONAL_GRID)


### PR DESCRIPTION
Workflow runs to completion, these mods are non-answer changing:
  nfiles_total = 82
  nfiles_missing = 0
  nfiles_different = 0
Final result of regression test:  PASS :)

Tested with
sorc/UFS_UTILS_develop head of dtc/develop branch
sorc/UFS_UTILS_chgres_grib2 hash c29174e
sorc/NEMSfv3gfs HEAD
sorc/EMC_post HEAD