### PR TITLE
Add predefined hrrr domains to latest workflow

### DIFF
--- a/ush/UFS_plot_domains.py
+++ b/ush/UFS_plot_domains.py
@@ -161,7 +161,7 @@ def get_lambert_points(gnomonic_map, lambert_map,pps):
 
 # Call the function we just defined to generate a polygon roughly approximating the lambert "rectangle" in gnomonic space
 
-verts3,codes3=get_lambert_points(map2, map3,10)
+verts3,codes3=get_lambert_points(map1, map3,10)
 
 # Now draw!
 

--- a/ush/UFS_plot_domains.py
+++ b/ush/UFS_plot_domains.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+
+import matplotlib.pyplot as plt
+from mpl_toolkits.basemap import Basemap
+from matplotlib.path import Path
+import matplotlib.patches as patches
+import numpy as np
+
+#### User-defined variables
+
+
+# Computational grid definitions
+JPgrid_LON_CTR=-153.0
+JPgrid_LAT_CTR=61.0
+JPgrid_DELX=3000.0
+JPgrid_DELY=3000.0
+JPgrid_NX=1344
+JPgrid_NY=1152
+
+# Write component grid definitions
+
+WRTCMP_nx=1340
+WRTCMP_ny=1132
+WRTCMP_lon_lwr_left=151.5
+WRTCMP_lat_lwr_left=42.360
+WRTCMP_dx=JPgrid_DELX
+WRTCMP_dy=JPgrid_DELY
+
+# Plot-specific definitions
+
+plot_res='i' # background map resolution
+
+#Note: Resolution can be 'c' (crude), 'l' (low), 'i' (intermediate), 'h' (high), or 'f' (full)
+#      To plot maps with higher resolution than low,
+#      you will need to download and install the basemap-data-hires package
+
+
+#### END User-defined variables
+
+
+
+JPgrid_width  = JPgrid_NX * JPgrid_DELX
+JPgrid_height = JPgrid_NY * JPgrid_DELY
+
+big_grid_width=np.ceil(JPgrid_width*1.25)
+big_grid_height=np.ceil(JPgrid_height*1.25)
+
+WRTCMP_width  = WRTCMP_nx * WRTCMP_dx
+WRTCMP_height = WRTCMP_ny * WRTCMP_dy
+
+fig = plt.figure()
+
+#ax1 = plt.axes
+ax1 = plt.subplot2grid((1,1), (0,0))
+
+map1 = Basemap(projection='gnom', resolution=plot_res, lon_0 = JPgrid_LON_CTR, lat_0 = JPgrid_LAT_CTR, 
+               width = big_grid_width, height=big_grid_height)
+
+map1.drawmapboundary(fill_color='#9999FF')
+map1.fillcontinents(color='#ddaa66',lake_color='#9999FF')
+map1.drawcoastlines()
+
+map2 = Basemap(projection='gnom', lon_0 = JPgrid_LON_CTR, lat_0 = JPgrid_LAT_CTR, 
+               width = JPgrid_width, height=JPgrid_height)
+
+#map2.drawmapboundary(fill_color='#9999FF')
+#map2.fillcontinents(color='#ddaa66',lake_color='#9999FF')
+#map2.drawcoastlines()
+
+
+map3 = Basemap(llcrnrlon= WRTCMP_lon_lwr_left, llcrnrlat=WRTCMP_lat_lwr_left, width=WRTCMP_width, height=WRTCMP_height,
+             resolution=plot_res, projection='lcc', lat_0 = JPgrid_LAT_CTR, lon_0 = JPgrid_LON_CTR)
+
+#map3.drawmapboundary(fill_color='#9999FF')
+#map3.fillcontinents(color='#ddaa66',lake_color='#9999FF',alpha=0.5)
+#map3.drawcoastlines()
+
+
+#Draw gnomonic compute grid rectangle:
+
+lbx1, lby1 = map1(*map2(map2.xmin, map2.ymin, inverse= True))
+ltx1, lty1 = map1(*map2(map2.xmin, map2.ymax, inverse= True))
+rtx1, rty1 = map1(*map2(map2.xmax, map2.ymax, inverse= True))
+rbx1, rby1 = map1(*map2(map2.xmax, map2.ymin, inverse= True))
+
+verts1 = [
+    (lbx1, lby1), # left, bottom
+    (ltx1, lty1), # left, top
+    (rtx1, rty1), # right, top
+    (rbx1, rby1), # right, bottom
+    (lbx1, lby1), # ignored
+    ]
+
+codes2 = [Path.MOVETO,
+         Path.LINETO,
+         Path.LINETO,
+         Path.LINETO,
+         Path.CLOSEPOLY,
+         ]
+
+path = Path(verts1, codes2)
+patch = patches.PathPatch(path, facecolor='r', lw=2,alpha=0.5)
+ax1.add_patch(patch)
+
+
+#Draw lambert write grid rectangle:
+
+# Define a function to get the lambert points in the gnomonic space
+
+def get_lambert_points(gnomonic_map, lambert_map,pps):
+    print("Hello from a function")
+    
+    # This function takes the lambert domain we have defined, lambert_map, as well as 
+    # pps (the number of points to interpolate and draw for each side of the lambert "rectangle"), 
+    # and returns an array of two lists: one a list of tuples of the 4*ppf + 4 vertices mapping the approximate shape 
+    # of the lambert domain on the gnomonic map, the other a list of "draw" instructions to be used by
+    # the PathPatch function
+    
+    # pps is recommended 10 or less due to time of calculation
+    
+    # Start array with bottom left point, "MOVETO" instruction
+    vertices = [gnomonic_map(*lambert_map(lambert_map.xmin, lambert_map.ymin, inverse= True))]
+    instructions = [Path.MOVETO]
+    
+    # Next generate the rest of the left side
+    lefty = np.linspace(lambert_map.ymin, lambert_map.ymax, num=pps+1, endpoint=False)
+    
+    for y in lefty[1:]:
+        vertices.append(tuple(gnomonic_map(*lambert_map(lambert_map.xmin, y, inverse= True))))
+        instructions.append(Path.LINETO)
+        
+    # Next generate the top of the domain
+    topx = np.linspace(lambert_map.xmin, lambert_map.xmax, num=pps+1, endpoint=False)
+    
+    for x in topx:
+        vertices.append(tuple(gnomonic_map(*lambert_map(x, lambert_map.ymax, inverse= True))))
+        instructions.append(Path.LINETO)
+
+    # Next generate the right side of the domain
+    righty = np.linspace(lambert_map.ymax, lambert_map.ymin, num=pps+1, endpoint=False)
+    
+    for y in righty:
+        vertices.append(tuple(gnomonic_map(*lambert_map(lambert_map.xmax, y, inverse= True))))
+        instructions.append(Path.LINETO)
+
+        
+    # Finally generate the bottom of the domain
+    bottomx = np.linspace(lambert_map.xmax, lambert_map.xmin, num=pps+1, endpoint=False)
+    
+    for x in bottomx:
+        vertices.append(tuple(gnomonic_map(*lambert_map(x, lambert_map.ymin, inverse= True))))
+        instructions.append(Path.LINETO)
+
+    # Need to replace final instruction with Path.CLOSEPOLY
+    instructions[-1] = Path.CLOSEPOLY
+
+    print ("vertices=",vertices)
+    print ("instructions=",instructions)
+
+    return vertices,instructions
+
+# Call the function we just defined to generate a polygon roughly approximating the lambert "rectangle" in gnomonic space
+
+verts3,codes3=get_lambert_points(map2, map3,10)
+
+# Now draw!
+
+path = Path(verts3, codes3)
+patch = patches.PathPatch(path, facecolor='w', lw=2,alpha=0.5)
+ax1.add_patch(patch)
+
+
+plt.show()
+
+

--- a/ush/set_predef_grid_params.sh
+++ b/ush/set_predef_grid_params.sh
@@ -920,6 +920,7 @@ predefined domain:
   elif [ "${GRID_GEN_METHOD}" = "JPgrid" ]; then
 
 # Values taken from pre-generated files in /scratch4/NCEPDEV/fv3-cam/save/Benjamin.Blake/regional_workflow/fix/fix_sar/hi/C768_grid.tile7.nc
+# With move to Hera, those files were lost; a backup can be found here: /scratch2/BMC/det/kavulich/fix/fix_sar
 # Longitude and latitude for center of domain
     JPgrid_LON_CTR=-157.0
     JPgrid_LAT_CTR=20.0
@@ -937,7 +938,7 @@ predefined domain:
 # Within the model we actually have a 4-point halo and a 3-point halo
     JPgrid_WIDE_HALO_WIDTH=6
 
-# Side note: FV3 is lagrangian and vertical coordinates are dynamically remapped during model integration (!!!)
+# Side note: FV3 is lagrangian and vertical coordinates are dynamically remapped during model integration
 # 'ksplit' is the factor that determines the timestep for this process (divided
 
 # Physics timestep in seconds, actual dynamics timestep can be a subset of this.
@@ -982,6 +983,177 @@ predefined domain:
 
    fi
    ;;
+
+#
+#-----------------------------------------------------------------------
+#
+# EMC's Puerto Rico grid.
+#
+#-----------------------------------------------------------------------
+#
+"EMC_PR")
+
+  if [ "${GRID_GEN_METHOD}" = "GFDLgrid" ]; then
+
+    print_err_msg_exit "\
+The parameters for a \"${GRID_GEN_METHOD}\" type grid have not yet been specified for this
+predefined domain:
+  PREDEF_GRID_NAME = \"${PREDEF_GRID_NAME}\"
+  GRID_GEN_METHOD = \"${GRID_GEN_METHOD}\"
+"
+
+  elif [ "${GRID_GEN_METHOD}" = "JPgrid" ]; then
+
+# Values taken from pre-generated files in /scratch4/NCEPDEV/fv3-cam/save/Benjamin.Blake/regional_workflow/fix/fix_sar/pr/C768_grid.tile7.nc
+# With move to Hera, those files were lost; a backup can be found here: /scratch2/BMC/det/kavulich/fix/fix_sar
+# Longitude and latitude for center of domain
+    JPgrid_LON_CTR=-69.0
+    JPgrid_LAT_CTR=18.0
+
+# Projected grid spacing in meters...in the static files (e.g. "C768_grid.tile7.nc"), the "dx" is actually the resolution
+# of the supergrid, which is HALF of this dx (plus or minus some grid stretch factor)
+    JPgrid_DELX="3000.0"
+    JPgrid_DELY="3000.0"
+
+# Number of x and y points for your domain (halo not included)
+    JPgrid_NX=1168
+    JPgrid_NY=880
+
+# Number of halo points for a wide grid (before trimming)...this should almost always be 6 for now
+# Within the model we actually have a 4-point halo and a 3-point halo
+    JPgrid_WIDE_HALO_WIDTH=6
+
+# Side note: FV3 is lagrangian and vertical coordinates are dynamically remapped during model integration
+# 'ksplit' is the factor that determines the timestep for this process (divided
+
+# Physics timestep in seconds, actual dynamics timestep can be a subset of this.
+# This is the time step for the largest atmosphere model loop.  It corresponds to the frequency with which the 
+# top-level routine in the dynamics is called as well as the frequency with which the physics is called.
+#
+# Preliminary standard values: 18 for 3-km runs, 90 for 13-km runs per config_defaults.sh
+
+    DT_ATMOS="18"
+
+#Factors for MPI decomposition. JPgrid_NX must be divisible by LAYOUT_X, JPgrid_NY must be divisible by LAYOUT_Y
+    LAYOUT_X="16"
+    LAYOUT_Y="10"
+
+#Take number of points on a tile (nx/lx*ny/ly), must divide by block size to get an integer.
+#This integer must be small enough to fit into a processor's cache, so it is machine-dependent magic
+# For Theia, must be ~40 or less
+# Check setup.sh for more details
+    BLOCKSIZE="22"
+
+#This section is all for the write component, which you need for output during model integration
+    if [ "$QUILTING" = "TRUE" ]; then
+#Write component reserves MPI tasks for writing output. The number of "groups" is usually 1, but if you have a case where group 1 is not done writing before the next write step, you need group 2, etc.
+      WRTCMP_write_groups="1"
+#Number of tasks per write group. Ny must be divisible my this number. LAYOUT_Y is usually a good value
+      WRTCMP_write_tasks_per_group="22"
+#lambert_conformal or rotated_latlon. lambert_conformal not well tested and probably doesn't work for our purposes
+      WRTCMP_output_grid="lambert_conformal"
+#These should always be set the same as compute grid
+      WRTCMP_cen_lon="${JPgrid_LON_CTR}"
+      WRTCMP_cen_lat="${JPgrid_LAT_CTR}"
+      WRTCMP_stdlat1="${JPgrid_LAT_CTR}"
+      WRTCMP_stdlat2="${JPgrid_LAT_CTR}"
+#Write component grid must always be <= compute grid (without haloes)
+      WRTCMP_nx="191"
+      WRTCMP_ny="97"
+#Lower left latlon (southwest corner)
+      WRTCMP_lon_lwr_left="-77.846"
+      WRTCMP_lat_lwr_left="12.341"
+      WRTCMP_dx="$JPgrid_DELX"
+      WRTCMP_dy="$JPgrid_DELY"
+    fi
+
+  fi
+  ;;
+#
+#-----------------------------------------------------------------------
+#
+# EMC's Guam grid.
+#
+#-----------------------------------------------------------------------
+#
+"EMC_GU")
+
+  if [ "${GRID_GEN_METHOD}" = "GFDLgrid" ]; then
+
+    print_err_msg_exit "\
+The parameters for a \"${GRID_GEN_METHOD}\" type grid have not yet been specified for this
+predefined domain:
+  PREDEF_GRID_NAME = \"${PREDEF_GRID_NAME}\"
+  GRID_GEN_METHOD = \"${GRID_GEN_METHOD}\"
+"
+
+  elif [ "${GRID_GEN_METHOD}" = "JPgrid" ]; then
+
+# Values taken from pre-generated files in /scratch4/NCEPDEV/fv3-cam/save/Benjamin.Blake/regional_workflow/fix/fix_sar/guam/C768_grid.tile7.nc
+# With move to Hera, those files were lost; a backup can be found here: /scratch2/BMC/det/kavulich/fix/fix_sar
+# Longitude and latitude for center of domain
+    JPgrid_LON_CTR=146.0
+    JPgrid_LAT_CTR=15.0
+
+# Projected grid spacing in meters...in the static files (e.g. "C768_grid.tile7.nc"), the "dx" is actually the resolution
+# of the supergrid, which is HALF of this dx (plus or minus some grid stretch factor)
+    JPgrid_DELX="3000.0"
+    JPgrid_DELY="3000.0"
+
+# Number of x and y points for your domain (halo not included)
+    JPgrid_NX=880
+    JPgrid_NY=736
+
+# Number of halo points for a wide grid (before trimming)...this should almost always be 6 for now
+# Within the model we actually have a 4-point halo and a 3-point halo
+    JPgrid_WIDE_HALO_WIDTH=6
+
+# Side note: FV3 is lagrangian and vertical coordinates are dynamically remapped during model integration
+# 'ksplit' is the factor that determines the timestep for this process (divided
+
+# Physics timestep in seconds, actual dynamics timestep can be a subset of this.
+# This is the time step for the largest atmosphere model loop.  It corresponds to the frequency with which the 
+# top-level routine in the dynamics is called as well as the frequency with which the physics is called.
+#
+# Preliminary standard values: 18 for 3-km runs, 90 for 13-km runs per config_defaults.sh
+
+    DT_ATMOS="18"
+
+#Factors for MPI decomposition. JPgrid_NX must be divisible by LAYOUT_X, JPgrid_NY must be divisible by LAYOUT_Y
+    LAYOUT_X="16"
+    LAYOUT_Y="16"
+#Take number of points on a tile (nx/lx*ny/ly), must divide by block size to get an integer.
+#This integer must be small enough to fit into a processor's cache, so it is machine-dependent magic
+# For Theia, must be ~40 or less
+# Check setup.sh for more details
+    BLOCKSIZE="23"
+
+#This section is all for the write component, which you need for output during model integration
+    if [ "$QUILTING" = "TRUE" ]; then
+#Write component reserves MPI tasks for writing output. The number of "groups" is usually 1, but if you have a case where group 1 is not done writing before the next write step, you need group 2, etc.
+      WRTCMP_write_groups="1"
+#Number of tasks per write group. Ny must be divisible my this number. LAYOUT_Y is usually a good value
+      WRTCMP_write_tasks_per_group="23"
+#lambert_conformal or rotated_latlon. lambert_conformal not well tested and probably doesn't work for our purposes
+      WRTCMP_output_grid="lambert_conformal"
+#These should always be set the same as compute grid
+      WRTCMP_cen_lon="${JPgrid_LON_CTR}"
+      WRTCMP_cen_lat="${JPgrid_LAT_CTR}"
+      WRTCMP_stdlat1="${JPgrid_LAT_CTR}"
+      WRTCMP_stdlat2="${JPgrid_LAT_CTR}"
+#Write component grid must always be <= compute grid (without haloes)
+      WRTCMP_nx="191"
+      WRTCMP_ny="97"
+#Lower left latlon (southwest corner)
+      WRTCMP_lon_lwr_left="138.941"
+      WRTCMP_lat_lwr_left="9.658"
+      WRTCMP_dx="$JPgrid_DELX"
+      WRTCMP_dy="$JPgrid_DELY"
+    fi
+
+  fi
+  ;;
+
 
 #
 esac

--- a/ush/set_predef_grid_params.sh
+++ b/ush/set_predef_grid_params.sh
@@ -975,12 +975,12 @@ predefined domain:
       WRTCMP_stdlat1="${JPgrid_LAT_CTR}"
       WRTCMP_stdlat2="${JPgrid_LAT_CTR}"
 #Write component grid should be close to the JPgrid values unless you are doing something weird
-      WRTCMP_nx="440"
-      WRTCMP_ny="368"
+      WRTCMP_nx="420"
+      WRTCMP_ny="348"
 
 #Lower left latlon (southwest corner)
-      WRTCMP_lon_lwr_left="-163.2"
-      WRTCMP_lat_lwr_left="14.9"
+      WRTCMP_lon_lwr_left="-162.8"
+      WRTCMP_lat_lwr_left="15.2"
       WRTCMP_dx="$JPgrid_DELX"
       WRTCMP_dy="$JPgrid_DELY"
     fi
@@ -1148,11 +1148,11 @@ predefined domain:
       WRTCMP_stdlat1="${JPgrid_LAT_CTR}"
       WRTCMP_stdlat2="${JPgrid_LAT_CTR}"
 #Write component grid must always be <= compute grid (without haloes)
-      WRTCMP_nx="871"
-      WRTCMP_ny="724"
-#Lower left latlon (southwest corner) (taken from 2019070100/INPUT/grid.tile7.halo4.nc)
-      WRTCMP_lon_lwr_left="132.856"
-      WRTCMP_lat_lwr_left="4.70778"
+      WRTCMP_nx="420"
+      WRTCMP_ny="348"
+#Lower left latlon (southwest corner) Used /scratch2/NCEPDEV/fv3-cam/Dusan.Jovic/dbrowse/fv3grid utility to find best value 
+      WRTCMP_lon_lwr_left="140"
+      WRTCMP_lat_lwr_left="10"
       WRTCMP_dx="$JPgrid_DELX"
       WRTCMP_dy="$JPgrid_DELY"
     fi

--- a/ush/set_predef_grid_params.sh
+++ b/ush/set_predef_grid_params.sh
@@ -756,14 +756,14 @@ predefined domain:
     DT_ATMOS="18"
 
 #Factors for MPI decomposition. JPgrid_NX must be divisible by LAYOUT_X, JPgrid_NY must be divisible by LAYOUT_Y
-    LAYOUT_X="12"
-    LAYOUT_Y="12"
+    LAYOUT_X="28"
+    LAYOUT_Y="16"
 
 #Take number of points on a tile (nx/lx*ny/ly), must divide by block size to get an integer.
 #This integer must be small enough to fit into a processor's cache, so it is machine-dependent magic
 # For Theia, must be ~40 or less
 # Check setup.sh for more details
-    BLOCKSIZE="32"
+    BLOCKSIZE="24"
 
 #This section is all for the write component, which you need for output during model integration
     if [ "$QUILTING" = "TRUE" ]; then

--- a/ush/set_predef_grid_params.sh
+++ b/ush/set_predef_grid_params.sh
@@ -725,6 +725,68 @@ predefined domain:
 
   elif [ "${GRID_GEN_METHOD}" = "JPgrid" ]; then
 
+# Values taken from pre-generated files in /scratch4/NCEPDEV/fv3-cam/save/Benjamin.Blake/regional_workflow/fix/fix_sar
+# Longitude and latitude for center of domain
+    lon_rgnl_ctr=-97.5
+    lat_rgnl_ctr=38.5
+
+# Projected grid spacing in meters...in the static files (e.g. "C768_grid.tile7.nc"), the "dx" is actually the resolution
+# of the supergrid, which is HALF of this dx
+    delx="3000.0"
+    dely="3000.0"
+
+# Number of x and y points for your domain (halo not included)
+    nx_T7=1344
+    ny_T7=1152
+
+# Number of halo points for a wide grid (before trimming)...this should almost always be 6 for now
+# Within the model we actually have a 4-point halo and a 3-point halo
+    nhw_T7=6
+
+# Side note: FV3 is lagrangian and vertical coordinates are dynamically remapped during model integration (!!!)
+# 'ksplit' is the factor that determines the timestep for this process (divided
+
+# Physics timestep in seconds, actual dynamics timestep can be a subset of this.
+# This is the time step for the largest atmosphere model loop.  It corresponds to the frequency with which the 
+# top-level routine in the dynamics is called as well as the frequency with which the physics is called.
+#
+# Preliminary standard values: 18 for 3-km runs, 90 for 13-km runs per config_defaults.sh
+
+    dt_atmos="18"
+
+#Factors for MPI decomposition. nx_T7 must be divisible by layout_x, ny_T7 must be divisible by layout_y
+    layout_x="12"
+    layout_y="12"
+
+#Take number of points on a tile (nx/lx*ny/ly), must divide by block size to get an integer.
+#This integer must be small enough to fit into a processor's cache, so it is machine-dependent magic
+# For Theia, must be ~40 or less
+# Check setup.sh for more details
+    blocksize="32"
+
+#This section is all for the write component, which you need for output during model integration
+    if [ "$QUILTING" = "TRUE" ]; then
+#Write component reserves MPI tasks for writing output. The number of "groups" is usually 1, but if you have a case where group 1 is not done writing before the next write step, you need group 2, etc.
+      WRTCMP_write_groups="1"
+#Number of tasks per write group. Ny must be divisible my this number. layout_y is usually a good value
+      WRTCMP_write_tasks_per_group="24"
+#lambert_conformal or rotated_latlon. lambert_conformal not well tested and probably doesn't work for our purposes
+      WRTCMP_output_grid="lambert_conformal"
+#These should always be set the same as compute grid
+      WRTCMP_cen_lon="${lon_rgnl_ctr}"
+      WRTCMP_cen_lat="${lat_rgnl_ctr}"
+      WRTCMP_stdlat1="${lat_rgnl_ctr}"
+      WRTCMP_stdlat2="${lat_rgnl_ctr}"
+#Write component grid must always be <= compute grid (without haloes)
+      WRTCMP_nx="191"
+      WRTCMP_ny="97"
+#Lower left latlon (southwest corner)
+      WRTCMP_lon_lwr_left="-121.587"
+      WRTCMP_lat_lwr_left="24.360"
+      WRTCMP_dx="$delx"
+      WRTCMP_dy="$dely"
+    fi
+
     print_err_msg_exit "\
 The parameters for a \"${GRID_GEN_METHOD}\" type grid have not yet been specified for this
 predefined domain:
@@ -841,6 +903,90 @@ predefined domain:
 
   fi
   ;;
+#
+#
+#-----------------------------------------------------------------------
+#
+# EMC's Hawaii grid.
+#
+#-----------------------------------------------------------------------
+#
+"EMC_HI")
+
+  if [ "${GRID_GEN_METHOD}" = "GFDLgrid" ]; then
+
+    print_err_msg_exit "\
+The parameters for a \"${GRID_GEN_METHOD}\" type grid have not yet been specified for this
+predefined domain:
+  PREDEF_GRID_NAME = \"${PREDEF_GRID_NAME}\"
+  GRID_GEN_METHOD = \"${GRID_GEN_METHOD}\""
+
+  elif [ "${GRID_GEN_METHOD}" = "JPgrid" ]; then
+
+# Values taken from pre-generated files in /scratch4/NCEPDEV/fv3-cam/save/Benjamin.Blake/regional_workflow/fix/fix_sar/hi/C768_grid.tile7.nc
+# Longitude and latitude for center of domain
+    lon_rgnl_ctr=-157.0
+    lat_rgnl_ctr=20.0
+
+# Projected grid spacing in meters...in the static files (e.g. "C768_grid.tile7.nc"), the "dx" is actually the resolution
+# of the supergrid, which is HALF of this dx (plus or minus some grid stretch factor)
+    delx="3000.0"
+    dely="3000.0"
+
+# Number of x and y points for your domain (halo not included)
+    nx_T7=880
+    ny_T7=736
+
+# Number of halo points for a wide grid (before trimming)...this should almost always be 6 for now
+# Within the model we actually have a 4-point halo and a 3-point halo
+    nhw_T7=6
+
+# Side note: FV3 is lagrangian and vertical coordinates are dynamically remapped during model integration (!!!)
+# 'ksplit' is the factor that determines the timestep for this process (divided
+
+# Physics timestep in seconds, actual dynamics timestep can be a subset of this.
+# This is the time step for the largest atmosphere model loop.  It corresponds to the frequency with which the 
+# top-level routine in the dynamics is called as well as the frequency with which the physics is called.
+#
+# Preliminary standard values: 18 for 3-km runs, 90 for 13-km runs per config_defaults.sh
+
+    dt_atmos="18"
+
+#Factors for MPI decomposition. nx_T7 must be divisible by layout_x, ny_T7 must be divisible by layout_y
+    layout_x="10"
+    layout_y="8"
+#Take number of points on a tile (nx/lx*ny/ly), must divide by block size to get an integer.
+#This integer must be small enough to fit into a processor's cache, so it is machine-dependent magic
+# For Theia, must be ~40 or less
+# Check setup.sh for more details
+    blocksize="32"
+
+#This section is all for the write component, which you need for output during model integration
+    if [ "$QUILTING" = "TRUE" ]; then
+#Write component reserves MPI tasks for writing output. The number of "groups" is usually 1, but if you have a case where group 1 is not done writing before the next write step, you need group 2, etc.
+      WRTCMP_write_groups="1"
+#Number of tasks per write group. Ny must be divisible my this number. layout_y is usually a good value
+      WRTCMP_write_tasks_per_group="23"
+#lambert_conformal or rotated_latlon. lambert_conformal not well tested and probably doesn't work for our purposes
+      WRTCMP_output_grid="lambert_conformal"
+#These should always be set the same as compute grid
+      WRTCMP_cen_lon="${lon_rgnl_ctr}"
+      WRTCMP_cen_lat="${lat_rgnl_ctr}"
+      WRTCMP_stdlat1="${lat_rgnl_ctr}"
+      WRTCMP_stdlat2="${lat_rgnl_ctr}"
+#Write component grid must always be <= compute grid (without haloes)
+      WRTCMP_nx="191"
+      WRTCMP_ny="97"
+#Lower left latlon (southwest corner)
+      WRTCMP_lon_lwr_left="-150.587"
+      WRTCMP_lat_lwr_left="14.623"
+      WRTCMP_dx="$delx"
+      WRTCMP_dy="$dely"
+    fi
+
+   fi
+   ;;
+
 #
 esac
 

--- a/ush/set_predef_grid_params.sh
+++ b/ush/set_predef_grid_params.sh
@@ -726,24 +726,25 @@ predefined domain:
   elif [ "${GRID_GEN_METHOD}" = "JPgrid" ]; then
 
 # Values taken from pre-generated files in /scratch4/NCEPDEV/fv3-cam/save/Benjamin.Blake/regional_workflow/fix/fix_sar
+# With move to Hera, those files were lost; a backup can be found here: /scratch2/BMC/det/kavulich/fix/fix_sar
 # Longitude and latitude for center of domain
-    lon_rgnl_ctr=-97.5
-    lat_rgnl_ctr=38.5
+    JPgrid_LON_CTR=-97.5
+    JPgrid_LAT_CTR=38.5
 
 # Projected grid spacing in meters...in the static files (e.g. "C768_grid.tile7.nc"), the "dx" is actually the resolution
 # of the supergrid, which is HALF of this dx
-    delx="3000.0"
-    dely="3000.0"
+    JPgrid_DELX="3000.0"
+    JPgrid_DELY="3000.0"
 
 # Number of x and y points for your domain (halo not included)
-    nx_T7=1344
-    ny_T7=1152
+    JPgrid_NX=1344
+    JPgrid_NY=1152
 
 # Number of halo points for a wide grid (before trimming)...this should almost always be 6 for now
 # Within the model we actually have a 4-point halo and a 3-point halo
-    nhw_T7=6
+    JPgrid_WIDE_HALO_WIDTH=6
 
-# Side note: FV3 is lagrangian and vertical coordinates are dynamically remapped during model integration (!!!)
+# Side note: FV3 is lagrangian and vertical coordinates are dynamically remapped during model integration
 # 'ksplit' is the factor that determines the timestep for this process (divided
 
 # Physics timestep in seconds, actual dynamics timestep can be a subset of this.
@@ -752,46 +753,41 @@ predefined domain:
 #
 # Preliminary standard values: 18 for 3-km runs, 90 for 13-km runs per config_defaults.sh
 
-    dt_atmos="18"
+    DT_ATMOS="18"
 
-#Factors for MPI decomposition. nx_T7 must be divisible by layout_x, ny_T7 must be divisible by layout_y
-    layout_x="12"
-    layout_y="12"
+#Factors for MPI decomposition. JPgrid_NX must be divisible by LAYOUT_X, JPgrid_NY must be divisible by LAYOUT_Y
+    LAYOUT_X="12"
+    LAYOUT_Y="12"
 
 #Take number of points on a tile (nx/lx*ny/ly), must divide by block size to get an integer.
 #This integer must be small enough to fit into a processor's cache, so it is machine-dependent magic
 # For Theia, must be ~40 or less
 # Check setup.sh for more details
-    blocksize="32"
+    BLOCKSIZE="32"
 
 #This section is all for the write component, which you need for output during model integration
     if [ "$QUILTING" = "TRUE" ]; then
 #Write component reserves MPI tasks for writing output. The number of "groups" is usually 1, but if you have a case where group 1 is not done writing before the next write step, you need group 2, etc.
       WRTCMP_write_groups="1"
-#Number of tasks per write group. Ny must be divisible my this number. layout_y is usually a good value
+#Number of tasks per write group. Ny must be divisible my this number. LAYOUT_Y is usually a good value
       WRTCMP_write_tasks_per_group="24"
 #lambert_conformal or rotated_latlon. lambert_conformal not well tested and probably doesn't work for our purposes
       WRTCMP_output_grid="lambert_conformal"
 #These should always be set the same as compute grid
-      WRTCMP_cen_lon="${lon_rgnl_ctr}"
-      WRTCMP_cen_lat="${lat_rgnl_ctr}"
-      WRTCMP_stdlat1="${lat_rgnl_ctr}"
-      WRTCMP_stdlat2="${lat_rgnl_ctr}"
+      WRTCMP_cen_lon="${JPgrid_LON_CTR}"
+      WRTCMP_cen_lat="${JPgrid_LAT_CTR}"
+      WRTCMP_stdlat1="${JPgrid_LAT_CTR}"
+      WRTCMP_stdlat2="${JPgrid_LAT_CTR}"
 #Write component grid must always be <= compute grid (without haloes)
       WRTCMP_nx="191"
       WRTCMP_ny="97"
 #Lower left latlon (southwest corner)
       WRTCMP_lon_lwr_left="-121.587"
       WRTCMP_lat_lwr_left="24.360"
-      WRTCMP_dx="$delx"
-      WRTCMP_dy="$dely"
+      WRTCMP_dx="$JPgrid_DELX"
+      WRTCMP_dy="$JPgrid_DELY"
     fi
 
-    print_err_msg_exit "\
-The parameters for a \"${GRID_GEN_METHOD}\" type grid have not yet been specified for this
-predefined domain:
-  PREDEF_GRID_NAME = \"${PREDEF_GRID_NAME}\"
-  GRID_GEN_METHOD = \"${GRID_GEN_METHOD}\""
 
   fi
   ;;
@@ -925,21 +921,21 @@ predefined domain:
 
 # Values taken from pre-generated files in /scratch4/NCEPDEV/fv3-cam/save/Benjamin.Blake/regional_workflow/fix/fix_sar/hi/C768_grid.tile7.nc
 # Longitude and latitude for center of domain
-    lon_rgnl_ctr=-157.0
-    lat_rgnl_ctr=20.0
+    JPgrid_LON_CTR=-157.0
+    JPgrid_LAT_CTR=20.0
 
 # Projected grid spacing in meters...in the static files (e.g. "C768_grid.tile7.nc"), the "dx" is actually the resolution
 # of the supergrid, which is HALF of this dx (plus or minus some grid stretch factor)
-    delx="3000.0"
-    dely="3000.0"
+    JPgrid_DELX="3000.0"
+    JPgrid_DELY="3000.0"
 
 # Number of x and y points for your domain (halo not included)
-    nx_T7=880
-    ny_T7=736
+    JPgrid_NX=880
+    JPgrid_NY=736
 
 # Number of halo points for a wide grid (before trimming)...this should almost always be 6 for now
 # Within the model we actually have a 4-point halo and a 3-point halo
-    nhw_T7=6
+    JPgrid_WIDE_HALO_WIDTH=6
 
 # Side note: FV3 is lagrangian and vertical coordinates are dynamically remapped during model integration (!!!)
 # 'ksplit' is the factor that determines the timestep for this process (divided
@@ -950,38 +946,38 @@ predefined domain:
 #
 # Preliminary standard values: 18 for 3-km runs, 90 for 13-km runs per config_defaults.sh
 
-    dt_atmos="18"
+    DT_ATMOS="18"
 
-#Factors for MPI decomposition. nx_T7 must be divisible by layout_x, ny_T7 must be divisible by layout_y
-    layout_x="10"
-    layout_y="8"
+#Factors for MPI decomposition. JPgrid_NX must be divisible by LAYOUT_X, JPgrid_NY must be divisible by LAYOUT_Y
+    LAYOUT_X="10"
+    LAYOUT_Y="8"
 #Take number of points on a tile (nx/lx*ny/ly), must divide by block size to get an integer.
 #This integer must be small enough to fit into a processor's cache, so it is machine-dependent magic
 # For Theia, must be ~40 or less
 # Check setup.sh for more details
-    blocksize="32"
+    BLOCKSIZE="32"
 
 #This section is all for the write component, which you need for output during model integration
     if [ "$QUILTING" = "TRUE" ]; then
 #Write component reserves MPI tasks for writing output. The number of "groups" is usually 1, but if you have a case where group 1 is not done writing before the next write step, you need group 2, etc.
       WRTCMP_write_groups="1"
-#Number of tasks per write group. Ny must be divisible my this number. layout_y is usually a good value
+#Number of tasks per write group. Ny must be divisible my this number. LAYOUT_Y is usually a good value
       WRTCMP_write_tasks_per_group="23"
 #lambert_conformal or rotated_latlon. lambert_conformal not well tested and probably doesn't work for our purposes
       WRTCMP_output_grid="lambert_conformal"
 #These should always be set the same as compute grid
-      WRTCMP_cen_lon="${lon_rgnl_ctr}"
-      WRTCMP_cen_lat="${lat_rgnl_ctr}"
-      WRTCMP_stdlat1="${lat_rgnl_ctr}"
-      WRTCMP_stdlat2="${lat_rgnl_ctr}"
+      WRTCMP_cen_lon="${JPgrid_LON_CTR}"
+      WRTCMP_cen_lat="${JPgrid_LAT_CTR}"
+      WRTCMP_stdlat1="${JPgrid_LAT_CTR}"
+      WRTCMP_stdlat2="${JPgrid_LAT_CTR}"
 #Write component grid must always be <= compute grid (without haloes)
       WRTCMP_nx="191"
       WRTCMP_ny="97"
 #Lower left latlon (southwest corner)
       WRTCMP_lon_lwr_left="-150.587"
       WRTCMP_lat_lwr_left="14.623"
-      WRTCMP_dx="$delx"
-      WRTCMP_dy="$dely"
+      WRTCMP_dx="$JPgrid_DELX"
+      WRTCMP_dy="$JPgrid_DELY"
     fi
 
    fi

--- a/ush/set_predef_grid_params.sh
+++ b/ush/set_predef_grid_params.sh
@@ -727,18 +727,20 @@ predefined domain:
 
 # Values taken from pre-generated files in /scratch4/NCEPDEV/fv3-cam/save/Benjamin.Blake/regional_workflow/fix/fix_sar
 # With move to Hera, those files were lost; a backup can be found here: /scratch2/BMC/det/kavulich/fix/fix_sar
+
 # Longitude and latitude for center of domain
-    JPgrid_LON_CTR=-97.5
-    JPgrid_LAT_CTR=38.5
+    JPgrid_LON_CTR=-153.0
+    JPgrid_LAT_CTR=61.0
 
 # Projected grid spacing in meters...in the static files (e.g. "C768_grid.tile7.nc"), the "dx" is actually the resolution
 # of the supergrid, which is HALF of this dx
     JPgrid_DELX="3000.0"
     JPgrid_DELY="3000.0"
 
-# Number of x and y points for your domain (halo not included)
-    JPgrid_NX=1344
-    JPgrid_NY=1152
+# Number of x and y points for your domain (halo not included);
+# Divide "supergrid" values from /scratch2/BMC/det/kavulich/fix/fix_sar/ak/C768_grid.tile7.halo4.nc by 2 and subtract 8 to eliminate halo
+    JPgrid_NX=1344 # Supergrid value 2704
+    JPgrid_NY=1152 # Supergrid value 2320
 
 # Number of halo points for a wide grid (before trimming)...this should almost always be 6 for now
 # Within the model we actually have a 4-point halo and a 3-point halo
@@ -779,8 +781,8 @@ predefined domain:
       WRTCMP_stdlat1="${JPgrid_LAT_CTR}"
       WRTCMP_stdlat2="${JPgrid_LAT_CTR}"
 #Write component grid must always be <= compute grid (without haloes)
-      WRTCMP_nx="191"
-      WRTCMP_ny="97"
+      WRTCMP_nx="1340"
+      WRTCMP_ny="1132"
 #Lower left latlon (southwest corner)
       WRTCMP_lon_lwr_left="-121.587"
       WRTCMP_lat_lwr_left="24.360"
@@ -972,8 +974,8 @@ predefined domain:
       WRTCMP_stdlat1="${JPgrid_LAT_CTR}"
       WRTCMP_stdlat2="${JPgrid_LAT_CTR}"
 #Write component grid must always be <= compute grid (without haloes)
-      WRTCMP_nx="191"
-      WRTCMP_ny="97"
+      WRTCMP_nx="871"
+      WRTCMP_ny="724"
 #Lower left latlon (southwest corner)
       WRTCMP_lon_lwr_left="-150.587"
       WRTCMP_lat_lwr_left="14.623"
@@ -1058,8 +1060,8 @@ predefined domain:
       WRTCMP_stdlat1="${JPgrid_LAT_CTR}"
       WRTCMP_stdlat2="${JPgrid_LAT_CTR}"
 #Write component grid must always be <= compute grid (without haloes)
-      WRTCMP_nx="191"
-      WRTCMP_ny="97"
+      WRTCMP_nx="1162"
+      WRTCMP_ny="864"
 #Lower left latlon (southwest corner)
       WRTCMP_lon_lwr_left="-77.846"
       WRTCMP_lat_lwr_left="12.341"
@@ -1142,8 +1144,8 @@ predefined domain:
       WRTCMP_stdlat1="${JPgrid_LAT_CTR}"
       WRTCMP_stdlat2="${JPgrid_LAT_CTR}"
 #Write component grid must always be <= compute grid (without haloes)
-      WRTCMP_nx="191"
-      WRTCMP_ny="97"
+      WRTCMP_nx="871"
+      WRTCMP_ny="724"
 #Lower left latlon (southwest corner)
       WRTCMP_lon_lwr_left="138.941"
       WRTCMP_lat_lwr_left="9.658"

--- a/ush/set_predef_grid_params.sh
+++ b/ush/set_predef_grid_params.sh
@@ -781,11 +781,11 @@ predefined domain:
       WRTCMP_stdlat1="${JPgrid_LAT_CTR}"
       WRTCMP_stdlat2="${JPgrid_LAT_CTR}"
 #Write component grid must always be <= compute grid (without haloes)
-      WRTCMP_nx="1340"
-      WRTCMP_ny="1132"
+      WRTCMP_nx="1344"
+      WRTCMP_ny="1152"
 #Lower left latlon (southwest corner)
-      WRTCMP_lon_lwr_left="151.5"
-      WRTCMP_lat_lwr_left="42.360"
+      WRTCMP_lon_lwr_left="-177.0"
+      WRTCMP_lat_lwr_left="42.5"
       WRTCMP_dx="$JPgrid_DELX"
       WRTCMP_dy="$JPgrid_DELY"
     fi
@@ -932,9 +932,10 @@ predefined domain:
     JPgrid_DELX="3000.0"
     JPgrid_DELY="3000.0"
 
-# Number of x and y points for your domain (halo not included)
-    JPgrid_NX=880
-    JPgrid_NY=736
+# Number of x and y points for your domain (halo not included);
+# Divide "supergrid" values from /scratch2/BMC/det/kavulich/fix/fix_sar/hi/C768_grid.tile7.halo4.nc by 2 and subtract 8 to eliminate halo
+    JPgrid_NX=432 # Supergrid value 880
+    JPgrid_NY=360 # Supergrid value 736
 
 # Number of halo points for a wide grid (before trimming)...this should almost always be 6 for now
 # Within the model we actually have a 4-point halo and a 3-point halo
@@ -952,33 +953,34 @@ predefined domain:
     DT_ATMOS="18"
 
 #Factors for MPI decomposition. JPgrid_NX must be divisible by LAYOUT_X, JPgrid_NY must be divisible by LAYOUT_Y
-    LAYOUT_X="10"
+    LAYOUT_X="8"
     LAYOUT_Y="8"
 #Take number of points on a tile (nx/lx*ny/ly), must divide by block size to get an integer.
 #This integer must be small enough to fit into a processor's cache, so it is machine-dependent magic
 # For Theia, must be ~40 or less
 # Check setup.sh for more details
-    BLOCKSIZE="32"
+    BLOCKSIZE="27"
 
 #This section is all for the write component, which you need for output during model integration
     if [ "$QUILTING" = "TRUE" ]; then
 #Write component reserves MPI tasks for writing output. The number of "groups" is usually 1, but if you have a case where group 1 is not done writing before the next write step, you need group 2, etc.
       WRTCMP_write_groups="1"
 #Number of tasks per write group. Ny must be divisible my this number. LAYOUT_Y is usually a good value
-      WRTCMP_write_tasks_per_group="23"
+      WRTCMP_write_tasks_per_group="8"
 #lambert_conformal or rotated_latlon. lambert_conformal not well tested and probably doesn't work for our purposes
       WRTCMP_output_grid="lambert_conformal"
-#These should always be set the same as compute grid
+#These should usually be set the same as compute grid
       WRTCMP_cen_lon="${JPgrid_LON_CTR}"
       WRTCMP_cen_lat="${JPgrid_LAT_CTR}"
       WRTCMP_stdlat1="${JPgrid_LAT_CTR}"
       WRTCMP_stdlat2="${JPgrid_LAT_CTR}"
-#Write component grid must always be <= compute grid (without haloes)
-      WRTCMP_nx="871"
-      WRTCMP_ny="724"
+#Write component grid should be close to the JPgrid values unless you are doing something weird
+      WRTCMP_nx="440"
+      WRTCMP_ny="368"
+
 #Lower left latlon (southwest corner)
-      WRTCMP_lon_lwr_left="189.399"
-      WRTCMP_lat_lwr_left="9.712"
+      WRTCMP_lon_lwr_left="-163.2"
+      WRTCMP_lat_lwr_left="14.9"
       WRTCMP_dx="$JPgrid_DELX"
       WRTCMP_dy="$JPgrid_DELY"
     fi
@@ -1017,9 +1019,10 @@ predefined domain:
     JPgrid_DELX="3000.0"
     JPgrid_DELY="3000.0"
 
-# Number of x and y points for your domain (halo not included)
-    JPgrid_NX=1168
-    JPgrid_NY=880
+# Number of x and y points for your domain (halo not included);
+# Divide "supergrid" values from /scratch2/BMC/det/kavulich/fix/fix_sar/pr/C768_grid.tile7.halo4.nc by 2 and subtract 8 to eliminate halo
+    JPgrid_NX=576 # Supergrid value 1168
+    JPgrid_NY=432 # Supergrid value 880
 
 # Number of halo points for a wide grid (before trimming)...this should almost always be 6 for now
 # Within the model we actually have a 4-point halo and a 3-point halo
@@ -1038,20 +1041,20 @@ predefined domain:
 
 #Factors for MPI decomposition. JPgrid_NX must be divisible by LAYOUT_X, JPgrid_NY must be divisible by LAYOUT_Y
     LAYOUT_X="16"
-    LAYOUT_Y="10"
+    LAYOUT_Y="8"
 
 #Take number of points on a tile (nx/lx*ny/ly), must divide by block size to get an integer.
 #This integer must be small enough to fit into a processor's cache, so it is machine-dependent magic
 # For Theia, must be ~40 or less
 # Check setup.sh for more details
-    BLOCKSIZE="22"
+    BLOCKSIZE="24"
 
 #This section is all for the write component, which you need for output during model integration
     if [ "$QUILTING" = "TRUE" ]; then
 #Write component reserves MPI tasks for writing output. The number of "groups" is usually 1, but if you have a case where group 1 is not done writing before the next write step, you need group 2, etc.
       WRTCMP_write_groups="1"
 #Number of tasks per write group. Ny must be divisible my this number. LAYOUT_Y is usually a good value
-      WRTCMP_write_tasks_per_group="22"
+      WRTCMP_write_tasks_per_group="24"
 #lambert_conformal or rotated_latlon. lambert_conformal not well tested and probably doesn't work for our purposes
       WRTCMP_output_grid="lambert_conformal"
 #These should always be set the same as compute grid
@@ -1060,11 +1063,11 @@ predefined domain:
       WRTCMP_stdlat1="${JPgrid_LAT_CTR}"
       WRTCMP_stdlat2="${JPgrid_LAT_CTR}"
 #Write component grid must always be <= compute grid (without haloes)
-      WRTCMP_nx="1162"
-      WRTCMP_ny="864"
+      WRTCMP_nx="576"
+      WRTCMP_ny="432"
 #Lower left latlon (southwest corner)
-      WRTCMP_lon_lwr_left="273.012"
-      WRTCMP_lat_lwr_left="5.603"
+      WRTCMP_lon_lwr_left="-77"
+      WRTCMP_lat_lwr_left="12"
       WRTCMP_dx="$JPgrid_DELX"
       WRTCMP_dy="$JPgrid_DELY"
     fi
@@ -1102,9 +1105,10 @@ predefined domain:
     JPgrid_DELX="3000.0"
     JPgrid_DELY="3000.0"
 
-# Number of x and y points for your domain (halo not included)
-    JPgrid_NX=880
-    JPgrid_NY=736
+# Number of x and y points for your domain (halo not included);
+# Divide "supergrid" values from /scratch2/BMC/det/kavulich/fix/fix_sar/guam/C768_grid.tile7.halo4.nc by 2 and subtract 8 to eliminate halo
+    JPgrid_NX=432 # Supergrid value 880
+    JPgrid_NY=360 # Supergrid value 736
 
 # Number of halo points for a wide grid (before trimming)...this should almost always be 6 for now
 # Within the model we actually have a 4-point halo and a 3-point halo
@@ -1123,19 +1127,19 @@ predefined domain:
 
 #Factors for MPI decomposition. JPgrid_NX must be divisible by LAYOUT_X, JPgrid_NY must be divisible by LAYOUT_Y
     LAYOUT_X="16"
-    LAYOUT_Y="16"
+    LAYOUT_Y="12"
 #Take number of points on a tile (nx/lx*ny/ly), must divide by block size to get an integer.
 #This integer must be small enough to fit into a processor's cache, so it is machine-dependent magic
 # For Theia, must be ~40 or less
 # Check setup.sh for more details
-    BLOCKSIZE="23"
+    BLOCKSIZE="27"
 
 #This section is all for the write component, which you need for output during model integration
     if [ "$QUILTING" = "TRUE" ]; then
 #Write component reserves MPI tasks for writing output. The number of "groups" is usually 1, but if you have a case where group 1 is not done writing before the next write step, you need group 2, etc.
       WRTCMP_write_groups="1"
 #Number of tasks per write group. Ny must be divisible my this number. LAYOUT_Y is usually a good value
-      WRTCMP_write_tasks_per_group="23"
+      WRTCMP_write_tasks_per_group="24"
 #lambert_conformal or rotated_latlon. lambert_conformal not well tested and probably doesn't work for our purposes
       WRTCMP_output_grid="lambert_conformal"
 #These should always be set the same as compute grid
@@ -1146,9 +1150,9 @@ predefined domain:
 #Write component grid must always be <= compute grid (without haloes)
       WRTCMP_nx="871"
       WRTCMP_ny="724"
-#Lower left latlon (southwest corner)
-      WRTCMP_lon_lwr_left="132.984"
-      WRTCMP_lat_lwr_left="4.820"
+#Lower left latlon (southwest corner) (taken from 2019070100/INPUT/grid.tile7.halo4.nc)
+      WRTCMP_lon_lwr_left="132.856"
+      WRTCMP_lat_lwr_left="4.70778"
       WRTCMP_dx="$JPgrid_DELX"
       WRTCMP_dy="$JPgrid_DELY"
     fi

--- a/ush/set_predef_grid_params.sh
+++ b/ush/set_predef_grid_params.sh
@@ -784,8 +784,8 @@ predefined domain:
       WRTCMP_nx="1340"
       WRTCMP_ny="1132"
 #Lower left latlon (southwest corner)
-      WRTCMP_lon_lwr_left="-121.587"
-      WRTCMP_lat_lwr_left="24.360"
+      WRTCMP_lon_lwr_left="151.5"
+      WRTCMP_lat_lwr_left="42.360"
       WRTCMP_dx="$JPgrid_DELX"
       WRTCMP_dy="$JPgrid_DELY"
     fi
@@ -977,8 +977,8 @@ predefined domain:
       WRTCMP_nx="871"
       WRTCMP_ny="724"
 #Lower left latlon (southwest corner)
-      WRTCMP_lon_lwr_left="-150.587"
-      WRTCMP_lat_lwr_left="14.623"
+      WRTCMP_lon_lwr_left="189.399"
+      WRTCMP_lat_lwr_left="9.712"
       WRTCMP_dx="$JPgrid_DELX"
       WRTCMP_dy="$JPgrid_DELY"
     fi
@@ -1063,8 +1063,8 @@ predefined domain:
       WRTCMP_nx="1162"
       WRTCMP_ny="864"
 #Lower left latlon (southwest corner)
-      WRTCMP_lon_lwr_left="-77.846"
-      WRTCMP_lat_lwr_left="12.341"
+      WRTCMP_lon_lwr_left="273.012"
+      WRTCMP_lat_lwr_left="5.603"
       WRTCMP_dx="$JPgrid_DELX"
       WRTCMP_dy="$JPgrid_DELY"
     fi
@@ -1147,8 +1147,8 @@ predefined domain:
       WRTCMP_nx="871"
       WRTCMP_ny="724"
 #Lower left latlon (southwest corner)
-      WRTCMP_lon_lwr_left="138.941"
-      WRTCMP_lat_lwr_left="9.658"
+      WRTCMP_lon_lwr_left="132.984"
+      WRTCMP_lat_lwr_left="4.820"
       WRTCMP_dx="$JPgrid_DELX"
       WRTCMP_dy="$JPgrid_DELY"
     fi

--- a/ush/valid_param_vals.sh
+++ b/ush/valid_param_vals.sh
@@ -2,7 +2,7 @@ valid_vals_RUN_ENVIR=("nco" "community")
 valid_vals_VERBOSE=("TRUE" "true" "YES" "yes" "FALSE" "false" "NO" "no")
 valid_vals_MACHINE=("WCOSS_C" "WCOSS" "DELL" "THEIA" "HERA" "JET" "ODIN" "CHEYENNE")
 valid_vals_PREDEF_GRID_NAME=( \
-"EMC_CONUS_3km" "EMC_CONUS_coarse" "EMC_AK" \
+"EMC_CONUS_3km" "EMC_CONUS_coarse" "EMC_AK" "EMC_HI" "EMC_PR" "EMC_GU" \
 "GSD_HAFSV0.A3km" "GSD_HAFSV0.A13km" "GSD_HAFSV0.A25km" \
 "GSD_HRRR_AK_3km" "GSD_HRRR_AK_50km" \
 "GSD_HRRR3km" "GSD_HRRR13km" "GSD_HRRR25km" \


### PR DESCRIPTION
This replaces PR #132.  

Adding the pre-defined domains for HI, PR, and GU to set_predef_grid_params.sh, and adding JPgrid write component configuration for AK. 

The values for these domains have been taken from fix files generated for old output grid, originally located on Hera at /scratch4/NCEPDEV/fv3-cam/save/Benjamin.Blake/fix_fv3cam/fix_sar but have since been scrubbed. I archived a copy here: /scratch2/BMC/det/kavulich/fix/fix_sar

## Tests run:
- [x] Test end-to-end through post
  - [x] Alaska
  - [x] Hawaii
  - [x] Puerto Rico
  - [x] Guam
- [x] View all domains to ensure they are geographically "sane"


## Feedback requested:

 - This AK domain may be a somewhat duplicate of the "GSD_HRRR_AK_3km" domain; let me know if it should be omitted
 -  I went with a pretty conservative number of nodes so currently all of these cases take a few hours to run. If the number of nodes should be increased let me know.