### PR TITLE
Fix for contrib module handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ This step will also copy the executables to the `exec` directory and link the fi
 On some platforms this environment is already available with a few commands;For example, on Jet/Hera:
 ```
 cd ush
-module load contrib miniconda3
+module use -a /contrib/miniconda3/modulefiles
+module load miniconda3
 conda activate regional_workflow
 ```
 on Cheyenne:
@@ -50,5 +51,5 @@ rocotostat -w FV3SAR_wflow.xml -d FV3SAR_wflow.db -v 10
 ```
 8.  For automatic resubmission of the workflow, the following can be added to your crontab:
 ```
-*/3 * * * * cd $EXPTDIR && rocotorun -w FV3SAR_wflow.xml -d FV3SAR_wflow.db -v 10
+*/3 * * * * cd $EXPTDIR && ./launch_FV3SAR_wflow.sh
 ```

--- a/modulefiles/tasks/hera/make_grid
+++ b/modulefiles/tasks/hera/make_grid
@@ -8,7 +8,7 @@ module load intel/18.0.5.274
 module load netcdf/4.7.0
 module load hdf5/1.10.5
 
-module load contrib
+module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
 if [module-info mode load] {
   system "conda activate regional_workflow"

--- a/modulefiles/tasks/hera/make_ics.hardcoded
+++ b/modulefiles/tasks/hera/make_ics.hardcoded
@@ -21,6 +21,6 @@ module load sigio/2.1.0
 
 module load wgrib2/2.0.8
 
-module load contrib
+module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
 conda activate regional_workflow

--- a/modulefiles/tasks/hera/make_ics.local
+++ b/modulefiles/tasks/hera/make_ics.local
@@ -1,5 +1,5 @@
 module load wgrib2/2.0.8 
 
-module load contrib
+module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
 conda activate regional_workflow

--- a/modulefiles/tasks/hera/make_lbcs.hardcoded
+++ b/modulefiles/tasks/hera/make_lbcs.hardcoded
@@ -21,6 +21,6 @@ module load sigio/2.1.0
 
 module load wgrib2/2.0.8
 
-module load contrib
+module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
 conda activate regional_workflow

--- a/modulefiles/tasks/hera/make_lbcs.local
+++ b/modulefiles/tasks/hera/make_lbcs.local
@@ -1,5 +1,5 @@
 module load wgrib2/2.0.8 
 
-module load contrib
+module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
 conda activate regional_workflow

--- a/modulefiles/tasks/jet/make_grid
+++ b/modulefiles/tasks/jet/make_grid
@@ -8,6 +8,6 @@ module load intel/18.0.5.274
 module load netcdf/4.7.0
 module load hdf5/1.10.5
 
-module load contrib
+module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
 system "conda activate regional_workflow"

--- a/modulefiles/tasks/jet/make_ics.hardcoded
+++ b/modulefiles/tasks/jet/make_ics.hardcoded
@@ -29,6 +29,6 @@ export WGRIB2_LIB="/apps/wgrib2/2.0.8/intel/18.0.5.274/lib/libwgrib2.a"
 export WGRIB2_DIR="/apps/wgrib2/2.0.8/intel/18.0.5.274/bin"
 module load wgrib2/2.0.8
 
-module load contrib
+module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
 conda activate regional_workflow

--- a/modulefiles/tasks/jet/make_ics.local
+++ b/modulefiles/tasks/jet/make_ics.local
@@ -1,5 +1,5 @@
 module load wgrib2/2.0.8 
 
-module load contrib
+module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
 conda activate regional_workflow

--- a/modulefiles/tasks/jet/make_lbcs.hardcoded
+++ b/modulefiles/tasks/jet/make_lbcs.hardcoded
@@ -29,6 +29,6 @@ export WGRIB2_LIB="/apps/wgrib2/2.0.8/intel/18.0.5.274/lib/libwgrib2.a"
 export WGRIB2_DIR="/apps/wgrib2/2.0.8/intel/18.0.5.274/bin"
 module load wgrib2/2.0.8
 
-module load contrib
+module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
 conda activate regional_workflow

--- a/modulefiles/tasks/jet/make_lbcs.local
+++ b/modulefiles/tasks/jet/make_lbcs.local
@@ -1,5 +1,5 @@
 module load wgrib2/2.0.8 
 
-module load contrib
+module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
 conda activate regional_workflow


### PR DESCRIPTION
## DESCRIPTION OF CHANGES:.
All the module files contained in this repository have been updated for the change on Jet/Hera to remove the contrib module, and instead use the `module use -a` method for locating necessary contrib package modulefiles. This will be the ONLY way to use these modules after June 11, 2020, and is already in place to work now. As such, this is a **time sensitive** PR.

## TESTS CONDUCTED:.
Loaded a few different modules on front end node. This included modules that need to be loaded, and those "modules" that are actually shell scripts and must be sourced. Both methods worked as expected.

I did not run any workflow tests.
