### PR TITLE
Bug fix -- Remove blank lines at start of rocoto XML template.  

### DIFF
--- a/ush/templates/FV3SAR_wflow.xml
+++ b/ush/templates/FV3SAR_wflow.xml
@@ -6,8 +6,7 @@ generate_workflow.sh step of preparing a regional workflow configured
 experiment.
 
 See README.xml_templating.md for information on using the Templating mechanisms.
-#}
-
+-#}
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE workflow [
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Blank lines at the start of the rocoto XML apparently cause the rocoto commands to fail.  So, in this PR, we modify the rocoto XML template as follows:
1) Remove all blank lines at start.  
2) Put in a dash with jinja end-of-comment, i.e. change #} to -#}, for the jinja comment at the start of the template so that jinja doesn't leave an extra blank line after processing.

## TESTS CONDUCTED: 
Conducted one WE2E test on hera.  Rocoto fails to start workflow without these changes, succeeds with.
