### PR TITLE
update FV3.input.yml for suites GSD_SAR_v1 and RRFS_v0

### DIFF
--- a/ush/templates/FV3.input.yml
+++ b/ush/templates/FV3.input.yml
@@ -36,13 +36,13 @@ FV3_GSD_SAR_v1:
   gfs_physics_nml:
     <<: *gsd_sar_phys
     lsm: 1
-    ttendlim: 0.005
+    lsoil_lsm: 4
 
 FV3_RRFS_v0:
   gfs_physics_nml:
     <<: *gsd_sar_phys
     lsm: 2
-    ttendlim: 0.005
+    lsoil_lsm: 4
 
 FV3_GFS_2017_gfdlmp:
   atmos_model_nml:


### PR DESCRIPTION
modified file:
         ush/templates/FV3.input.yml

updated FV3.input.yml for suites GSD_SAR_v1 and RRFS_v0

removing ttendlim: 0.005 and adding lsoil_lsm: 4

The modification is tested on Hera and passed.

