### PR TITLE
Make the location of the make_orog fix files more flexible

### DIFF
--- a/scripts/exregional_make_orog.sh
+++ b/scripts/exregional_make_orog.sh
@@ -147,7 +147,6 @@ case $MACHINE in
 
 "STAMPEDE")
   export APRUN="time"
-  export topo_dir="/work/00315/tg455890/stampede2/regional_fv3/fix_orog"
   ;;
 
 esac
@@ -172,15 +171,6 @@ mkdir_vrfy -p "${filter_dir}"
 shave_dir="${OROG_DIR}/shave_tmp"
 mkdir_vrfy -p "${shave_dir}"
 #
-#-----------------------------------------------------------------------
-#
-# Set the system directory from which topography data will be copied into
-# the experiment directory so it can be remapped onto the forecast model's
-# grid.
-#
-#-----------------------------------------------------------------------
-#
-topo_dir=$( readlink -f "${FIXgsm}/../fix_orog" )
 #
 #-----------------------------------------------------------------------
 #

--- a/scripts/exregional_make_orog.sh
+++ b/scripts/exregional_make_orog.sh
@@ -197,12 +197,12 @@ tmp_dir="${raw_dir}/tmp"
 mkdir_vrfy -p "${tmp_dir}"
 cd_vrfy "${tmp_dir}"
 #
-# Copy topography and related data files from the system directory (topo_dir)
+# Copy topography and related data files from the system directory (TOPO_DIR)
 # to the temporary directory.
 #
-cp_vrfy ${topo_dir}/thirty.second.antarctic.new.bin fort.15
-cp_vrfy ${topo_dir}/landcover30.fixed .
-cp_vrfy ${topo_dir}/gmted2010.30sec.int fort.235
+cp_vrfy ${TOPO_DIR}/thirty.second.antarctic.new.bin fort.15
+cp_vrfy ${TOPO_DIR}/landcover30.fixed .
+cp_vrfy ${TOPO_DIR}/gmted2010.30sec.int fort.235
 #
 #-----------------------------------------------------------------------
 #
@@ -303,7 +303,7 @@ ${TILE_RGNL} \
 ${FIXsar} \
 ${raw_dir} \
 ${UFS_UTILS_DIR} \
-${topo_dir} \
+${TOPO_DIR} \
 ${tmp_dir}" \
   >> ${tmp_dir}/orog.file1
 

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -900,15 +900,16 @@ SFC_CLIMO_FIELDS=( \
 # Set parameters associated with the fixed (i.e. static) files.  Definitions:
 #
 # FIXgsm:
-# The location on disk of the majority of the static input files.
+# System directory in which the majority of fixed (i.e. time-independent) 
+# files that are needed to run the FV3SAR model are located
 #
-# topo_dir:
-# The location on disk of the static input files used by the make_orog task.
-# Can be the same as FIXgsm.
+# TOPO_DIR:
+# The location on disk of the static input files used by the make_orog
+# task (orog.x and shave.x). Can be the same as FIXgsm.
 #
 # SFC_CLIMO_INPUT_DIR:
-# The location on disk of the static surface climatology input fields. These
-# files are only used if RUN_TASK_MAKE_SFC_CLIMO=FALSE
+# The location on disk of the static surface climatology input fields, used by 
+# sfc_climo_gen. These files are only used if RUN_TASK_MAKE_SFC_CLIMO=TRUE
 #
 # FNGLAC, ..., FNMSKH:
 # Names of (some of the) global data files that are assumed to exist in 
@@ -961,7 +962,7 @@ SFC_CLIMO_FIELDS=( \
 # to a null string which will then be overwritten in setup.sh unless the
 # user has specified a different value in config.sh
 FIXgsm=""
-topo_dir=""
+TOPO_DIR=""
 SFC_CLIMO_INPUT_DIR=""
 
 FNGLAC="global_glacier.2x2.grb"

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -899,6 +899,17 @@ SFC_CLIMO_FIELDS=( \
 #
 # Set parameters associated with the fixed (i.e. static) files.  Definitions:
 #
+# FIXgsm:
+# The location on disk of the majority of the static input files.
+#
+# topo_dir:
+# The location on disk of the static input files used by the make_orog task.
+# Can be the same as FIXgsm.
+#
+# SFC_CLIMO_INPUT_DIR:
+# The location on disk of the static surface climatology input fields. These
+# files are only used if RUN_TASK_MAKE_SFC_CLIMO=FALSE
+#
 # FNGLAC, ..., FNMSKH:
 # Names of (some of the) global data files that are assumed to exist in 
 # a system directory specified (this directory is machine-dependent; 
@@ -946,6 +957,13 @@ SFC_CLIMO_FIELDS=( \
 #
 #-----------------------------------------------------------------------
 #
+# Because the default values are dependent on the platform, we set these
+# to a null string which will then be overwritten in setup.sh unless the
+# user has specified a different value in config.sh
+FIXgsm=""
+topo_dir=""
+SFC_CLIMO_INPUT_DIR=""
+
 FNGLAC="global_glacier.2x2.grb"
 FNMXIC="global_maxice.2x2.grb"
 FNTSFC="RTGSST.1982.2012.monthly.clim.grb"

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -652,64 +652,68 @@ TEMPLATE_DIR="$USHDIR/templates"
 case $MACHINE in
 
 "WCOSS_CRAY")
-  FIXgsm="/gpfs/hps3/emc/global/noscrub/emc.glopara/git/fv3gfs/fix/fix_am"
-  topo_dir="/gpfs/hps3/emc/global/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"
-  SFC_CLIMO_INPUT_DIR=""
+  FIXgsm=${FIXgsm:-"/gpfs/hps3/emc/global/noscrub/emc.glopara/git/fv3gfs/fix/fix_am"}
+  topo_dir=${topo_dir:-"/gpfs/hps3/emc/global/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"}
+  SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-""}
   ;;
 
 "WCOSS_DELL_P3")
-  FIXgsm="/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_am"
-  topo_dir="/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"
-  SFC_CLIMO_INPUT_DIR=""
+  FIXgsm=${FIXgsm:-"/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_am"}
+  topo_dir=${topo_dir:-"/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"}
+  SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-""}
   ;;
 
 "DELL")
-  FIXgsm="/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_am"
-  topo_dir="/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"
-  SFC_CLIMO_INPUT_DIR=""
+  FIXgsm=${FIXgsm:-"/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_am"}
+  topo_dir=${topo_dir:-"/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"}
+  SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-""}
   ;;
 
 "THEIA")
-  FIXgsm="/scratch4/NCEPDEV/global/save/glopara/git/fv3gfs/fix/fix_am"
-  topo_dir="/scratch4/NCEPDEV/global/save/glopara/git/fv3gfs/fix/fix_orog"
-  SFC_CLIMO_INPUT_DIR="/scratch4/NCEPDEV/da/noscrub/George.Gayno/climo_fields_netcdf"
+  FIXgsm=${FIXgsm:-"/scratch4/NCEPDEV/global/save/glopara/git/fv3gfs/fix/fix_am"}
+  topo_dir=${topo_dir:-"/scratch4/NCEPDEV/global/save/glopara/git/fv3gfs/fix/fix_orog"}
+  SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/scratch4/NCEPDEV/da/noscrub/George.Gayno/climo_fields_netcdf"}
   ;;
 
 "HERA")
-  FIXgsm="/scratch1/NCEPDEV/global/glopara/fix/fix_am"
-  topo_dir="/scratch1/NCEPDEV/global/glopara/fix/fix_orog"
-  SFC_CLIMO_INPUT_DIR="/scratch1/NCEPDEV/da/George.Gayno/ufs_utils.git/climo_fields_netcdf"
+  FIXgsm=${FIXgsm:-"/scratch1/NCEPDEV/global/glopara/fix/fix_am"}
+  topo_dir=${topo_dir:-"/scratch1/NCEPDEV/global/glopara/fix/fix_orog"}
+  SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/scratch1/NCEPDEV/da/George.Gayno/ufs_utils.git/climo_fields_netcdf"}
   ;;
 
 "JET")
-  FIXgsm="/lfs4/HFIP/gsd-fv3-hfip/FV3/fix/fix_am"
-  topo_dir="/lfs4/HFIP/gsd-fv3-hfip/FV3/fix/fix_orog"
-  SFC_CLIMO_INPUT_DIR="/lfs1/HFIP/hwrf-data/git/fv3gfs/fix/fix_sfc_climo"
+  FIXgsm=${FIXgsm:-"/lfs4/HFIP/gsd-fv3-hfip/FV3/fix/fix_am"}
+  topo_dir=${topo_dir:-"/lfs4/HFIP/gsd-fv3-hfip/FV3/fix/fix_orog"}
+  SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/lfs1/HFIP/hwrf-data/git/fv3gfs/fix/fix_sfc_climo"}
   ;;
 
 "ODIN")
-  FIXgsm="/scratch/ywang/fix/theia_fix/fix_am"
-  topo_dir="/scratch/ywang/fix/theia_fix/fix_orog"
-  SFC_CLIMO_INPUT_DIR="/scratch/ywang/fix/climo_fields_netcdf"
+  FIXgsm=${FIXgsm:-"/scratch/ywang/fix/theia_fix/fix_am"}
+  topo_dir=${topo_dir:-"/scratch/ywang/fix/theia_fix/fix_orog"}
+  SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/scratch/ywang/fix/climo_fields_netcdf"}
   ;;
 "CHEYENNE")
-  FIXgsm="/glade/p/ral/jntp/UFS_CAM/fix/fix_am"
-  topo_dir="/glade/p/ral/jntp/UFS_CAM/fix/fix_orog"
-  SFC_CLIMO_INPUT_DIR="/glade/p/ral/jntp/UFS_CAM/fix/climo_fields_netcdf"
+  FIXgsm=${FIXgsm:-"/glade/p/ral/jntp/UFS_CAM/fix/fix_am"}
+  topo_dir=${topo_dir:-"/glade/p/ral/jntp/UFS_CAM/fix/fix_orog"}
+  SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/glade/p/ral/jntp/UFS_CAM/fix/climo_fields_netcdf"}
   ;;
 
 "STAMPEDE")
-  FIXgsm="/work/00315/tg455890/stampede2/regional_fv3/fix_am"
-  topo_dir="/work/00315/tg455890/stampede2/regional_fv3/fix_orog"
-  SFC_CLIMO_INPUT_DIR="/work/00315/tg455890/stampede2/regional_fv3/climo_fields_netcdf"
+  FIXgsm=${FIXgsm:-"/work/00315/tg455890/stampede2/regional_fv3/fix_am"}
+  topo_dir=${topo_dir:-"/work/00315/tg455890/stampede2/regional_fv3/fix_orog"}
+  SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/work/00315/tg455890/stampede2/regional_fv3/climo_fields_netcdf"}
   ;;
 
 *)
   print_err_msg_exit "\
-Directories have not been specified for this machine:
-  MACHINE = \"$MACHINE\""
-  ;;
+One or more fix file directories have not been specified for this machine:
+  MACHINE = \"$MACHINE\"
+  FIXgsm = \"${FIXgsm:-\"\"}
+  topo_dir = \"${topo_dir:-\"\"}
+  SFC_CLIMO_INPUT_DIR = \"${SFC_CLIMO_INPUT_DIR:-\"\"}
 
+You can specify the missing location(s) in config.sh"
+  ;;
 esac
 #
 #-----------------------------------------------------------------------

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -608,6 +608,10 @@ HH_FIRST_CYCL=${CYCL_HRS[0]}
 # System directory in which the fixed (i.e. time-independent) files that
 # are needed to run the FV3SAR model are located.
 #
+# topo_dir:
+# Directory in which the fixed (i.e. time-independent) files that are
+# needed to run the make_orog component (orog.x and shave.x) are located.
+#
 # SFC_CLIMO_INPUT_DIR:
 # Directory in which the sfc_climo_gen code looks for surface climatolo-
 # gy input files.
@@ -649,45 +653,54 @@ case $MACHINE in
 
 "WCOSS_CRAY")
   FIXgsm="/gpfs/hps3/emc/global/noscrub/emc.glopara/git/fv3gfs/fix/fix_am"
+  topo_dir="/gpfs/hps3/emc/global/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"
   SFC_CLIMO_INPUT_DIR=""
   ;;
 
 "WCOSS_DELL_P3")
   FIXgsm="/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_am"
+  topo_dir="/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"
   SFC_CLIMO_INPUT_DIR=""
   ;;
 
 "DELL")
   FIXgsm="/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_am"
+  topo_dir="/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"
   SFC_CLIMO_INPUT_DIR=""
   ;;
 
 "THEIA")
   FIXgsm="/scratch4/NCEPDEV/global/save/glopara/git/fv3gfs/fix/fix_am"
+  topo_dir="/scratch4/NCEPDEV/global/save/glopara/git/fv3gfs/fix/fix_orog"
   SFC_CLIMO_INPUT_DIR="/scratch4/NCEPDEV/da/noscrub/George.Gayno/climo_fields_netcdf"
   ;;
 
 "HERA")
   FIXgsm="/scratch1/NCEPDEV/global/glopara/fix/fix_am"
+  topo_dir="/scratch1/NCEPDEV/global/glopara/fix/fix_orog"
   SFC_CLIMO_INPUT_DIR="/scratch1/NCEPDEV/da/George.Gayno/ufs_utils.git/climo_fields_netcdf"
   ;;
 
 "JET")
   FIXgsm="/lfs4/HFIP/gsd-fv3-hfip/FV3/fix/fix_am"
+  topo_dir="/lfs4/HFIP/gsd-fv3-hfip/FV3/fix/fix_orog"
   SFC_CLIMO_INPUT_DIR="/lfs1/HFIP/hwrf-data/git/fv3gfs/fix/fix_sfc_climo"
   ;;
 
 "ODIN")
   FIXgsm="/scratch/ywang/fix/theia_fix/fix_am"
+  topo_dir="/scratch/ywang/fix/theia_fix/fix_orog"
   SFC_CLIMO_INPUT_DIR="/scratch/ywang/fix/climo_fields_netcdf"
   ;;
 "CHEYENNE")
   FIXgsm="/glade/p/ral/jntp/UFS_CAM/fix/fix_am"
+  topo_dir="/glade/p/ral/jntp/UFS_CAM/fix/fix_orog"
   SFC_CLIMO_INPUT_DIR="/glade/p/ral/jntp/UFS_CAM/fix/climo_fields_netcdf"
   ;;
 
 "STAMPEDE")
   FIXgsm="/work/00315/tg455890/stampede2/regional_fv3/fix_am"
+  topo_dir="/work/00315/tg455890/stampede2/regional_fv3/fix_orog"
   SFC_CLIMO_INPUT_DIR="/work/00315/tg455890/stampede2/regional_fv3/climo_fields_netcdf"
   ;;
 
@@ -2400,6 +2413,7 @@ UFS_WTHR_MDL_DIR="${UFS_WTHR_MDL_DIR}"
 UFS_UTILS_DIR="${UFS_UTILS_DIR}"
 CHGRES_DIR="${CHGRES_DIR}"
 SFC_CLIMO_INPUT_DIR="${SFC_CLIMO_INPUT_DIR}"
+topo_dir=${topo_dir}
 
 EXPTDIR="$EXPTDIR"
 LOGDIR="$LOGDIR"

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -604,18 +604,6 @@ HH_FIRST_CYCL=${CYCL_HRS[0]}
 # This directory includes subdirectories for FV3, NEMS, and FMS.  If
 # USE_CCPP is set to "TRUE", it also includes a subdirectory for CCPP.
 #
-# FIXgsm:
-# System directory in which the fixed (i.e. time-independent) files that
-# are needed to run the FV3SAR model are located.
-#
-# topo_dir:
-# Directory in which the fixed (i.e. time-independent) files that are
-# needed to run the make_orog component (orog.x and shave.x) are located.
-#
-# SFC_CLIMO_INPUT_DIR:
-# Directory in which the sfc_climo_gen code looks for surface climatolo-
-# gy input files.
-#
 # FIXupp:
 # System directory from which to copy necessary fixed files for UPP.
 #
@@ -653,54 +641,54 @@ case $MACHINE in
 
 "WCOSS_CRAY")
   FIXgsm=${FIXgsm:-"/gpfs/hps3/emc/global/noscrub/emc.glopara/git/fv3gfs/fix/fix_am"}
-  topo_dir=${topo_dir:-"/gpfs/hps3/emc/global/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"}
+  TOPO_DIR=${TOPO_DIR:-"/gpfs/hps3/emc/global/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"}
   SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-""}
   ;;
 
 "WCOSS_DELL_P3")
   FIXgsm=${FIXgsm:-"/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_am"}
-  topo_dir=${topo_dir:-"/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"}
+  TOPO_DIR=${TOPO_DIR:-"/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"}
   SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-""}
   ;;
 
 "DELL")
   FIXgsm=${FIXgsm:-"/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_am"}
-  topo_dir=${topo_dir:-"/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"}
+  TOPO_DIR=${TOPO_DIR:-"/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"}
   SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-""}
   ;;
 
 "THEIA")
   FIXgsm=${FIXgsm:-"/scratch4/NCEPDEV/global/save/glopara/git/fv3gfs/fix/fix_am"}
-  topo_dir=${topo_dir:-"/scratch4/NCEPDEV/global/save/glopara/git/fv3gfs/fix/fix_orog"}
+  TOPO_DIR=${TOPO_DIR:-"/scratch4/NCEPDEV/global/save/glopara/git/fv3gfs/fix/fix_orog"}
   SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/scratch4/NCEPDEV/da/noscrub/George.Gayno/climo_fields_netcdf"}
   ;;
 
 "HERA")
   FIXgsm=${FIXgsm:-"/scratch1/NCEPDEV/global/glopara/fix/fix_am"}
-  topo_dir=${topo_dir:-"/scratch1/NCEPDEV/global/glopara/fix/fix_orog"}
+  TOPO_DIR=${TOPO_DIR:-"/scratch1/NCEPDEV/global/glopara/fix/fix_orog"}
   SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/scratch1/NCEPDEV/da/George.Gayno/ufs_utils.git/climo_fields_netcdf"}
   ;;
 
 "JET")
   FIXgsm=${FIXgsm:-"/lfs4/HFIP/gsd-fv3-hfip/FV3/fix/fix_am"}
-  topo_dir=${topo_dir:-"/lfs4/HFIP/gsd-fv3-hfip/FV3/fix/fix_orog"}
+  TOPO_DIR=${TOPO_DIR:-"/lfs4/HFIP/gsd-fv3-hfip/FV3/fix/fix_orog"}
   SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/lfs1/HFIP/hwrf-data/git/fv3gfs/fix/fix_sfc_climo"}
   ;;
 
 "ODIN")
   FIXgsm=${FIXgsm:-"/scratch/ywang/fix/theia_fix/fix_am"}
-  topo_dir=${topo_dir:-"/scratch/ywang/fix/theia_fix/fix_orog"}
+  TOPO_DIR=${TOPO_DIR:-"/scratch/ywang/fix/theia_fix/fix_orog"}
   SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/scratch/ywang/fix/climo_fields_netcdf"}
   ;;
 "CHEYENNE")
   FIXgsm=${FIXgsm:-"/glade/p/ral/jntp/UFS_CAM/fix/fix_am"}
-  topo_dir=${topo_dir:-"/glade/p/ral/jntp/UFS_CAM/fix/fix_orog"}
+  TOPO_DIR=${TOPO_DIR:-"/glade/p/ral/jntp/UFS_CAM/fix/fix_orog"}
   SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/glade/p/ral/jntp/UFS_CAM/fix/climo_fields_netcdf"}
   ;;
 
 "STAMPEDE")
   FIXgsm=${FIXgsm:-"/work/00315/tg455890/stampede2/regional_fv3/fix_am"}
-  topo_dir=${topo_dir:-"/work/00315/tg455890/stampede2/regional_fv3/fix_orog"}
+  TOPO_DIR=${TOPO_DIR:-"/work/00315/tg455890/stampede2/regional_fv3/fix_orog"}
   SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/work/00315/tg455890/stampede2/regional_fv3/climo_fields_netcdf"}
   ;;
 
@@ -709,7 +697,7 @@ case $MACHINE in
 One or more fix file directories have not been specified for this machine:
   MACHINE = \"$MACHINE\"
   FIXgsm = \"${FIXgsm:-\"\"}
-  topo_dir = \"${topo_dir:-\"\"}
+  TOPO_DIR = \"${TOPO_DIR:-\"\"}
   SFC_CLIMO_INPUT_DIR = \"${SFC_CLIMO_INPUT_DIR:-\"\"}
 
 You can specify the missing location(s) in config.sh"
@@ -2417,7 +2405,7 @@ UFS_WTHR_MDL_DIR="${UFS_WTHR_MDL_DIR}"
 UFS_UTILS_DIR="${UFS_UTILS_DIR}"
 CHGRES_DIR="${CHGRES_DIR}"
 SFC_CLIMO_INPUT_DIR="${SFC_CLIMO_INPUT_DIR}"
-topo_dir=${topo_dir}
+TOPO_DIR=${TOPO_DIR}
 
 EXPTDIR="$EXPTDIR"
 LOGDIR="$LOGDIR"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Previously, in exregional_make_orog.sh, a local variable "topo_dir" was used as the location of the fix files for the make_orog task, and this variable was hard-coded as a path relative to the global "FIXgsm" variable. Now topo_dir is set as a global variable in setup.sh, just like FIXgsm and SFC_CLIMO_INPUT_DIR, to allow more flexibility for the location of these fixed input files.

In addition, all of these paths can now be directly specified by the user in config.sh, rather than needing to modify setup.sh every time you want to point to a new fix file location.

## TESTS CONDUCTED: 
Ran a standard end-to-end case on Cheyenne (GSD_HRRR25km, 2019090118), and also ran the same test where I pointed to fixed data that I had copied to different directories via the config.sh file. These tests performed as expected.

Also successfully ran test suites on Hera (GSD_RAP13km new_JPgrid regional_002 regional_005 regional_006 regional_007 regional_008 regional_015, the rest have current known issues) and Jet (). These were successful as expected: unless the user modified their config.sh file to include one of these new paths, the workflow's behavior should not change.


