### PR TITLE
Add check to generate_FV3SAR_wflow.sh for correct python environment

### DIFF
--- a/ush/generate_FV3SAR_wflow.sh
+++ b/ush/generate_FV3SAR_wflow.sh
@@ -63,19 +63,25 @@ echo "Version= ${pyversion[*]}"
 echo ${pyversion[0]}
 echo ${pyversion[1]}
 
+#Now, set an error check variable so that we can print all python errors rather than just the first
+pyerrors=0
+
 # Check that the call to python3 returned no errors, then check if the 
 # python3 minor version is 6 or higher
 if [[ -z "$pyversion" ]];then
-  print_err_msg_exit "\
-  Error: python3 not found, check your python environment"
+  print_info_msg "\
+  Error: python3 not found"
+  pyerrors=$((pyerrors+1))
 else
   if [[ ${#pyversion[@]} -lt 2 ]]; then
-    print_err_msg_exit "\
-    Error retrieving python3 version; check your python environment\n"
+    print_info_msg "\
+    Error retrieving python3 version"
+    pyerrors=$((pyerrors+1))
   elif [[ ${pyversion[1]} -lt 6 ]]; then
-    print_err_msg_exit "\
+    print_info_msg "\
     Error: python version must be 3.6 or higher
-    python version: ${pyversion[*]}\n"
+    python version: ${pyversion[*]}"
+    pyerrors=$((pyerrors+1))
   fi
 fi
 
@@ -83,10 +89,20 @@ fi
 pkgs=(jinja2 yaml f90nml)
 for pkg in ${pkgs[@]}  ; do
   if ! /usr/bin/env python3 -c "import ${pkg}" &> /dev/null; then
-  print_err_msg_exit "\
-  python module ${pkg} not available; check your python environment\n"
+  print_info_msg "\
+  python module ${pkg} not available"
+  pyerrors=$((pyerrors+1))
   fi
 done
+
+#Finally, check if the number of errors is >0, and if so exit with helpful message
+if [ $pyerrors -gt 0 ];then
+  print_err_msg_exit "\
+  Errors found: check your python environment
+  
+  Instructions for setting up python environments can be found on the web:
+  https://github.com/ufs-community/ufs-srweather-app/wiki/Getting-Started"
+fi
 
 #
 #-----------------------------------------------------------------------

--- a/ush/generate_FV3SAR_wflow.sh
+++ b/ush/generate_FV3SAR_wflow.sh
@@ -52,6 +52,48 @@ ushdir="${scrfunc_dir}"
 #
 #-----------------------------------------------------------------------
 #
+# Run python checks
+#
+#-----------------------------------------------------------------------
+#
+
+# This line will return two numbers: the python major and minor versions
+pyversion=($(/usr/bin/env python3 -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(major); print(minor)'))
+echo "Version= ${pyversion[*]}"
+echo ${pyversion[0]}
+echo ${pyversion[1]}
+
+# Check that the call to python3 returned no errors, then check if the 
+# python3 minor version is 6 or higher
+if [[ -z "$pyversion" ]];then
+  print_err_msg_exit "\
+  Error: python3 not found, check your python environment"
+else
+  if [[ ${#pyversion[@]} -lt 2 ]]; then
+    print_err_msg_exit "\
+    Error retrieving python3 version; check your python environment\n"
+  elif [[ ${pyversion[1]} -lt 4 ]]; then
+    print_err_msg_exit "\
+    Error: python version must be 3.6 or higher
+    python version: ${pyversion[*]}\n"
+  fi
+fi
+
+#Next, check for the three non-standard python packages: jinja2, yaml, and f90nml
+if ! /usr/bin/env python3 -c "import jinja2" &> /dev/null; then
+    print_err_msg_exit "\
+    python module 'jinja2' not available; check your python environment\n"
+elif ! /usr/bin/env python3 -c "import yaml" &> /dev/null; then
+    print_err_msg_exit "\
+    python module 'yaml' not available; check your python environment\n"
+elif ! /usr/bin/env python3 -c "import f90nml" &> /dev/null; then
+    print_err_msg_exit "\
+    python module 'f90nml' not available; check your python environment\n"
+fi
+
+#
+#-----------------------------------------------------------------------
+#
 # Save current shell options (in a global array).  Then set new options
 # for this script/function.
 #

--- a/ush/generate_FV3SAR_wflow.sh
+++ b/ush/generate_FV3SAR_wflow.sh
@@ -59,9 +59,6 @@ ushdir="${scrfunc_dir}"
 
 # This line will return two numbers: the python major and minor versions
 pyversion=($(/usr/bin/env python3 -c 'import platform; major, minor, patch = platform.python_version_tuple(); print(major); print(minor)'))
-echo "Version= ${pyversion[*]}"
-echo ${pyversion[0]}
-echo ${pyversion[1]}
 
 #Now, set an error check variable so that we can print all python errors rather than just the first
 pyerrors=0
@@ -70,17 +67,20 @@ pyerrors=0
 # python3 minor version is 6 or higher
 if [[ -z "$pyversion" ]];then
   print_info_msg "\
+
   Error: python3 not found"
   pyerrors=$((pyerrors+1))
 else
   if [[ ${#pyversion[@]} -lt 2 ]]; then
     print_info_msg "\
-    Error retrieving python3 version"
+
+  Error retrieving python3 version"
     pyerrors=$((pyerrors+1))
   elif [[ ${pyversion[1]} -lt 6 ]]; then
     print_info_msg "\
-    Error: python version must be 3.6 or higher
-    python version: ${pyversion[*]}"
+
+  Error: python version must be 3.6 or higher
+  python version: ${pyversion[*]}"
     pyerrors=$((pyerrors+1))
   fi
 fi
@@ -90,7 +90,8 @@ pkgs=(jinja2 yaml f90nml)
 for pkg in ${pkgs[@]}  ; do
   if ! /usr/bin/env python3 -c "import ${pkg}" &> /dev/null; then
   print_info_msg "\
-  python module ${pkg} not available"
+
+  Error: python module ${pkg} not available"
   pyerrors=$((pyerrors+1))
   fi
 done
@@ -101,7 +102,9 @@ if [ $pyerrors -gt 0 ];then
   Errors found: check your python environment
   
   Instructions for setting up python environments can be found on the web:
-  https://github.com/ufs-community/ufs-srweather-app/wiki/Getting-Started"
+  https://github.com/ufs-community/ufs-srweather-app/wiki/Getting-Started
+
+"
 fi
 
 #

--- a/ush/generate_FV3SAR_wflow.sh
+++ b/ush/generate_FV3SAR_wflow.sh
@@ -72,24 +72,21 @@ else
   if [[ ${#pyversion[@]} -lt 2 ]]; then
     print_err_msg_exit "\
     Error retrieving python3 version; check your python environment\n"
-  elif [[ ${pyversion[1]} -lt 4 ]]; then
+  elif [[ ${pyversion[1]} -lt 6 ]]; then
     print_err_msg_exit "\
     Error: python version must be 3.6 or higher
     python version: ${pyversion[*]}\n"
   fi
 fi
 
-#Next, check for the three non-standard python packages: jinja2, yaml, and f90nml
-if ! /usr/bin/env python3 -c "import jinja2" &> /dev/null; then
-    print_err_msg_exit "\
-    python module 'jinja2' not available; check your python environment\n"
-elif ! /usr/bin/env python3 -c "import yaml" &> /dev/null; then
-    print_err_msg_exit "\
-    python module 'yaml' not available; check your python environment\n"
-elif ! /usr/bin/env python3 -c "import f90nml" &> /dev/null; then
-    print_err_msg_exit "\
-    python module 'f90nml' not available; check your python environment\n"
-fi
+#Next, check for the non-standard python packages: jinja2, yaml, and f90nml
+pkgs=(jinja2 yaml f90nml)
+for pkg in ${pkgs[@]}  ; do
+  if ! /usr/bin/env python3 -c "import ${pkg}" &> /dev/null; then
+  print_err_msg_exit "\
+  python module ${pkg} not available; check your python environment\n"
+  fi
+done
 
 #
 #-----------------------------------------------------------------------


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
As it currently exists, the generate_FV3SAR_wflow.sh script can fail in some non-obvious ways if the correct python environment is not available. This PR adds some checks at the beginning of this script for the required python version and python modules that are needed to successfully set up the regional workflow, so the script will immediately fail with a descriptive error message if the necessary python environment is not available.

The error messaging is still not ideal, as the structure of this script does not allow for a simple exit upon error and still outputs some spurious error messages, but this is an improvement over the previous behavior in the case of a bad python environment.

## TESTS CONDUCTED: 
Ran checks on Cheyenne, Jet, and Hera for the script's expected behavior. When the correct python environment was loaded, behavior did not change, as expected. When python versions or modules were insufficient, the script now fails immediately, and outputs a descriptive error message about the unmet requirement. 

Also ran the end-to-end workflow tests on Hera, there was no change in behavior.
