### PR TITLE
CMake build for regional_workflow

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "CMakeModules"]
+	path = CMakeModules
+	url = https://github.com/NOAA-EMC/CMakeModules.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.15)
+
+project(regional_workflow LANGUAGES Fortran)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules/Modules")
+
+find_package(NetCDF COMPONENTS Fortran)
+
+add_subdirectory(sorc)
+
+

--- a/sorc/CMakeLists.txt
+++ b/sorc/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_subdirectory(global_equiv_resol.fd)
+add_subdirectory(mosaic_file.fd)
+add_subdirectory(regional_grid.fd)

--- a/sorc/global_equiv_resol.fd/CMakeLists.txt
+++ b/sorc/global_equiv_resol.fd/CMakeLists.txt
@@ -1,0 +1,10 @@
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "-g -O2")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
+  set(CMAKE_Fortran_FLAGS "-g -O2")
+endif()
+
+
+add_executable(global_equiv_resol global_equiv_resol.f90)
+target_link_libraries(global_equiv_resol NetCDF::NetCDF_Fortran)

--- a/sorc/global_equiv_resol.fd/CMakeLists.txt
+++ b/sorc/global_equiv_resol.fd/CMakeLists.txt
@@ -8,3 +8,9 @@ endif()
 
 add_executable(global_equiv_resol global_equiv_resol.f90)
 target_link_libraries(global_equiv_resol NetCDF::NetCDF_Fortran)
+
+
+install(
+  TARGETS global_equiv_resol
+  RUNTIME DESTINATION bin
+  )

--- a/sorc/global_equiv_resol.fd/global_equiv_resol.f90
+++ b/sorc/global_equiv_resol.fd/global_equiv_resol.f90
@@ -131,7 +131,7 @@ program global_equiv_resol
   WRITE(*,530) "  min_cell_size = ", min_cell_size
   WRITE(*,530) "  max_cell_size = ", max_cell_size
   WRITE(*,530) "  avg_cell_size = ", avg_cell_size
-530 FORMAT(A, G)
+530 FORMAT(A, G0)
 !
 !=======================================================================
 !

--- a/sorc/mosaic_file.fd/CMakeLists.txt
+++ b/sorc/mosaic_file.fd/CMakeLists.txt
@@ -8,3 +8,9 @@ endif()
 
 add_executable(mosaic_file mosaic_file.f90)
 target_link_libraries(mosaic_file NetCDF::NetCDF_Fortran)
+
+
+install(
+  TARGETS mosaic_file
+  RUNTIME DESTINATION bin
+  )

--- a/sorc/mosaic_file.fd/CMakeLists.txt
+++ b/sorc/mosaic_file.fd/CMakeLists.txt
@@ -1,0 +1,10 @@
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "-g -O2")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
+  set(CMAKE_Fortran_FLAGS "-g -O2")
+endif()
+
+
+add_executable(mosaic_file mosaic_file.f90)
+target_link_libraries(mosaic_file NetCDF::NetCDF_Fortran)

--- a/sorc/regional_grid.fd/CMakeLists.txt
+++ b/sorc/regional_grid.fd/CMakeLists.txt
@@ -9,3 +9,9 @@ set(src_files pkind.f90 pietc.f90 pmat.f90 pmat4.f90 pmat5.f90 psym2.f90 gen_sch
 
 add_executable(regional_grid ${src_files})
 target_link_libraries(regional_grid NetCDF::NetCDF_Fortran)
+
+
+install(
+  TARGETS regional_grid
+  RUNTIME DESTINATION bin
+  )

--- a/sorc/regional_grid.fd/CMakeLists.txt
+++ b/sorc/regional_grid.fd/CMakeLists.txt
@@ -1,0 +1,11 @@
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+  set(CMAKE_Fortran_FLAGS "-g -O2")
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
+  set(CMAKE_Fortran_FLAGS "-g -O2")
+endif()
+
+set(src_files pkind.f90 pietc.f90 pmat.f90 pmat4.f90 pmat5.f90 psym2.f90 gen_schmidt.f90 hgrid_ak.f90 regional_grid.f90)
+
+add_executable(regional_grid ${src_files})
+target_link_libraries(regional_grid NetCDF::NetCDF_Fortran)


### PR DESCRIPTION
I see that there are some things that are going to be moved around/removed from this repo and that some of this may not be necessary. Let me know if any of this will still be useful.

## DESCRIPTION OF CHANGES: 
CMake build for regional_workflow. This PR changes no code, aside from a format specifier without a width in a print statement in global_equiv_resol so that it can be built with gfortran (which doesn't allow it).

Added CMakeModules as a Git submodule which is required for FindNetCDF

## TESTS CONDUCTED: 
I have built it using the same build options in the makefiles using both gfortran and ifort on my local machine and on Hera. The executables work, but I don't know how to run actual tests.

To build:

```
mkdir build
cd build 
cmake .. -DCMAKE_INSTALL_PREFIX=install
make
make install
```

This places the executables in a `bin` directory at CMAKE_INSTALL_PREFIX.

