### PR TITLE
Change grib2 file name forecast hour precision from two to three digits

### DIFF
--- a/jobs/JREGIONAL_RUN_POST
+++ b/jobs/JREGIONAL_RUN_POST
@@ -108,16 +108,6 @@ digits:
   fhr = \"${fhr}\""
 fi
 #
-# Add check to make sure fhr contains exactly two digits.  This restriction
-# needs to be removed at some point.
-#
-fhr=$( printf "%s" "${fhr}" | sed -n -r -e "s/^([0-9]{2})$/\1/p" )
-if [ -z "$fhr" ]; then
-  print_err_msg_exit "\
-Currently, the forecast hour (fhr) must consist of exactly two digits:
-  fhr = \"${fhr}\""
-fi
-#
 #-----------------------------------------------------------------------
 #
 # Call the ex-script for this J-job and pass to it the necessary varia-

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -217,20 +217,15 @@ zero exit code."
 #
 len_fhr=${#fhr}
 if [ ${len_fhr} -eq 2 ]; then
-
 post_fhr=${fhr}
-
 elif [ ${len_fhr} -eq 3 ]; then
-
   if [ "${fhr:0:1}" = "0" ]; then
     post_fhr="${fhr:1}"
   fi
-
 else
-
-echo "The \${fhr} variable contains too few or too many characters!"
-echo "fhr = \"$fhr\""
-
+print_err_msg_exit "\
+The \${fhr} variable contains too few or too many characters:
+  fhr = \"$fhr\""
 fi
 
 mv_vrfy BGDAWP.GrbF${post_fhr} ${postprd_dir}/${NET}.t${cyc}z.bgdawpf${fhr}.${tmmark}.grib2

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -167,8 +167,8 @@ tmmark="tm$hh"
 #
 #-----------------------------------------------------------------------
 #
-dyn_file="${run_dir}/dynf0${fhr}.nc"
-phy_file="${run_dir}/phyf0${fhr}.nc"
+dyn_file="${run_dir}/dynf${fhr}.nc"
+phy_file="${run_dir}/phyf${fhr}.nc"
 
 post_time=$( date --utc --date "${yyyymmdd} ${hh} UTC + ${fhr} hours" "+%Y%m%d%H" )
 post_yyyy=${post_time:0:4}
@@ -206,9 +206,35 @@ zero exit code."
 #
 #-----------------------------------------------------------------------
 #
+#
+#-----------------------------------------------------------------------
+#
+# A separate ${post_fhr} forecast hour variable is required for the post 
+# files, since they may or may not be three digits long, depending on the
+# length of the forecast.
+#
+#-----------------------------------------------------------------------
+#
+len_fhr=${#fhr}
+if [ ${len_fhr} -eq 2 ]; then
 
-mv_vrfy BGDAWP.GrbF${fhr} ${postprd_dir}/${NET}.t${cyc}z.bgdawpf${fhr}.${tmmark}.grib2
-mv_vrfy BGRD3D.GrbF${fhr} ${postprd_dir}/${NET}.t${cyc}z.bgrd3df${fhr}.${tmmark}.grib2
+post_fhr=${fhr}
+
+elif [ ${len_fhr} -eq 3 ]; then
+
+  if [ "${fhr:0:1}" = "0" ]; then
+    post_fhr="${fhr:1}"
+  fi
+
+else
+
+echo "The \${fhr} variable contains too few or too many characters!"
+echo "fhr = \"$fhr\""
+
+fi
+
+mv_vrfy BGDAWP.GrbF${post_fhr} ${postprd_dir}/${NET}.t${cyc}z.bgdawpf${fhr}.${tmmark}.grib2
+mv_vrfy BGRD3D.GrbF${post_fhr} ${postprd_dir}/${NET}.t${cyc}z.bgrd3df${fhr}.${tmmark}.grib2
 
 #Link output for transfer to Jet
 # Should the following be done only if on jet??

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -217,13 +217,13 @@ zero exit code."
 #
 len_fhr=${#fhr}
 if [ ${len_fhr} -eq 2 ]; then
-post_fhr=${fhr}
+  post_fhr=${fhr}
 elif [ ${len_fhr} -eq 3 ]; then
   if [ "${fhr:0:1}" = "0" ]; then
     post_fhr="${fhr:1}"
   fi
 else
-print_err_msg_exit "\
+  print_err_msg_exit "\
 The \${fhr} variable contains too few or too many characters:
   fhr = \"$fhr\""
 fi

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -221,7 +221,7 @@ start_date=$( echo "${cdate}" | sed 's/\([[:digit:]]\{2\}\)$/ \1/' )
 basetime=$( date +%y%j%H%M -d "${start_date}" )
 ln_vrfy -fs ${postprd_dir}/${NET}.t${cyc}z.bgdawpf${fhr}.${tmmark}.grib2 \
             ${postprd_dir}/BGDAWP_${basetime}f${fhr}00
-ln_vrfy -fs ${postprd_dir}/${NET}.t${cyc}z.bgrd3d${fhr}.${tmmark}.grib2 \
+ln_vrfy -fs ${postprd_dir}/${NET}.t${cyc}z.bgrd3df${fhr}.${tmmark}.grib2 \
             ${postprd_dir}/BGRD3D_${basetime}f${fhr}00
 
 rm_vrfy -rf ${fhr_dir}

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -207,8 +207,8 @@ zero exit code."
 #-----------------------------------------------------------------------
 #
 
-mv_vrfy BGDAWP.GrbF${fhr} ${postprd_dir}/rrfs.t${cyc}z.bgdawpf${fhr}.${tmmark}.grib2
-mv_vrfy BGRD3D.GrbF${fhr} ${postprd_dir}/rrfs.t${cyc}z.bgrd3df${fhr}.${tmmark}.grib2
+mv_vrfy BGDAWP.GrbF${fhr} ${postprd_dir}/${NET}.t${cyc}z.bgdawpf${fhr}.${tmmark}.grib2
+mv_vrfy BGRD3D.GrbF${fhr} ${postprd_dir}/${NET}.t${cyc}z.bgrd3df${fhr}.${tmmark}.grib2
 
 #Link output for transfer to Jet
 # Should the following be done only if on jet??
@@ -219,10 +219,10 @@ mv_vrfy BGRD3D.GrbF${fhr} ${postprd_dir}/rrfs.t${cyc}z.bgrd3df${fhr}.${tmmark}.g
 # instead of calling sed.
 start_date=$( echo "${cdate}" | sed 's/\([[:digit:]]\{2\}\)$/ \1/' )
 basetime=$( date +%y%j%H%M -d "${start_date}" )
-ln_vrfy -fs ${postprd_dir}/rrfs.t${cyc}z.bgdawpf${fhr}.${tmmark}.grib2 \
-            ${postprd_dir}/BGDAWP_${basetime}${fhr}00
-ln_vrfy -fs ${postprd_dir}/RRFS.t${cyc}z.bgrd3d${fhr}.${tmmark}.grib2 \
-            ${postprd_dir}/BGRD3D_${basetime}${fhr}00
+ln_vrfy -fs ${postprd_dir}/${NET}.t${cyc}z.bgdawpf${fhr}.${tmmark}.grib2 \
+            ${postprd_dir}/BGDAWP_${basetime}f${fhr}00
+ln_vrfy -fs ${postprd_dir}/${NET}.t${cyc}z.bgrd3d${fhr}.${tmmark}.grib2 \
+            ${postprd_dir}/BGRD3D_${basetime}f${fhr}00
 
 rm_vrfy -rf ${fhr_dir}
 #

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -207,8 +207,8 @@ zero exit code."
 #-----------------------------------------------------------------------
 #
 
-mv_vrfy BGDAWP.GrbF${fhr} ${postprd_dir}/RRFS.t${cyc}z.bgdawp${fhr}.${tmmark}
-mv_vrfy BGRD3D.GrbF${fhr} ${postprd_dir}/RRFS.t${cyc}z.bgrd3d${fhr}.${tmmark}
+mv_vrfy BGDAWP.GrbF${fhr} ${postprd_dir}/rrfs.t${cyc}z.bgdawpf${fhr}.${tmmark}.grib2
+mv_vrfy BGRD3D.GrbF${fhr} ${postprd_dir}/rrfs.t${cyc}z.bgrd3df${fhr}.${tmmark}.grib2
 
 #Link output for transfer to Jet
 # Should the following be done only if on jet??
@@ -219,9 +219,9 @@ mv_vrfy BGRD3D.GrbF${fhr} ${postprd_dir}/RRFS.t${cyc}z.bgrd3d${fhr}.${tmmark}
 # instead of calling sed.
 start_date=$( echo "${cdate}" | sed 's/\([[:digit:]]\{2\}\)$/ \1/' )
 basetime=$( date +%y%j%H%M -d "${start_date}" )
-ln_vrfy -fs ${postprd_dir}/RRFS.t${cyc}z.bgdawp${fhr}.${tmmark} \
+ln_vrfy -fs ${postprd_dir}/rrfs.t${cyc}z.bgdawpf${fhr}.${tmmark}.grib2 \
             ${postprd_dir}/BGDAWP_${basetime}${fhr}00
-ln_vrfy -fs ${postprd_dir}/RRFS.t${cyc}z.bgrd3d${fhr}.${tmmark} \
+ln_vrfy -fs ${postprd_dir}/RRFS.t${cyc}z.bgrd3d${fhr}.${tmmark}.grib2 \
             ${postprd_dir}/BGRD3D_${basetime}${fhr}00
 
 rm_vrfy -rf ${fhr_dir}

--- a/ush/Python/plot_allvars.py
+++ b/ush/Python/plot_allvars.py
@@ -237,7 +237,7 @@ cyc = str(hour).zfill(2)
 print(year, month, day, hour)
 
 fhr = int(sys.argv[2])
-fhour = str(fhr).zfill(2)
+fhour = str(fhr).zfill(3)
 print('fhour '+fhour)
 itime = ymdh
 vtime = ndate(itime,int(fhr))
@@ -247,7 +247,7 @@ EXPT_SUBDIR = str(sys.argv[4])
 CARTOPY_DIR = str(sys.argv[5])
 
 # Define the location of the input file
-data1 = pygrib.open(EXPT_BASEDIR+'/'+EXPT_SUBDIR+'/'+ymdh+'/postprd/RRFS.t'+cyc+'z.bgdawp'+fhour+'.tm00.grib2')
+data1 = pygrib.open(EXPT_BASEDIR+'/'+EXPT_SUBDIR+'/'+ymdh+'/postprd/rrfs.t'+cyc+'z.bgdawpf'+fhour+'.tm00.grib2')
 
 # Get the lats and lons
 grids = [data1]

--- a/ush/templates/FV3LAM_wflow.xml
+++ b/ush/templates/FV3LAM_wflow.xml
@@ -375,7 +375,7 @@ MODULES_RUN_TASK_FP script.
 -->
   <metatask name="&RUN_POST_TN;{{ uscore_ensmem_name }}">
 
-    <var name="fhr"> {% for h in range(0, fcst_len_hrs+1) %}{{ " %02d" % h  }}{% endfor %} </var>
+    <var name="fhr"> {% for h in range(0, fcst_len_hrs+1) %}{{ " %03d" % h  }}{% endfor %} </var>
 
     <task name="&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr#" maxtries="1">
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Changes forecast hour precision from two to three digits, and adds an "f" prior to the forecast hour in the final grib2 file names.  Requested by GSL.  

Modifies the plot_allvars.py Python script to match this convention.

## TESTS CONDUCTED: 
Tested successfully on Hera with both HRRR3km and HRRR25km domains.

## CONTRIBUTORS (optional): 
@gsketefian 

