### PR TITLE
Add new subconus 3km predefined grid; add WE2E tests for this and the GSD_HRRR25km grid.

### DIFF
--- a/tests/baseline_configs/config.nco_GSD_HRRR25km_HRRRX_RAPX.sh
+++ b/tests/baseline_configs/config.nco_GSD_HRRR25km_HRRRX_RAPX.sh
@@ -1,0 +1,111 @@
+#
+# The values of the variables MACHINE, ACCOUNT, and EXPT_SUBDIR are required
+# inputs to the script that launces the WE2E test experiments.  That script 
+# will use those inputs to fill in the values of these variables below.
+#
+MACHINE=""
+ACCOUNT=""
+EXPT_SUBDIR=""
+#
+# The values of the variables USE_CRON_TO_RELAUNCH and CRON_RELAUNCH_INTVL_MNTS
+# are optional inputs to the script that launces the WE2E test experiments.  
+# If one or both of these values are specified, then that script will 
+# replace the default values of these variables below with those values.
+# Otherwise, it will keep the default values.
+#
+USE_CRON_TO_RELAUNCH="TRUE"
+CRON_RELAUNCH_INTVL_MNTS="02"
+
+VERBOSE="TRUE"
+
+RUN_ENVIR="nco"
+PREEXISTING_DIR_METHOD="rename"
+
+EMC_GRID_NAME="GSD_HRRR25km"
+GRID_GEN_METHOD="ESGgrid"
+
+QUILTING="TRUE"
+USE_CCPP="TRUE"
+CCPP_PHYS_SUITE="FV3_GSD_SAR"
+FCST_LEN_HRS="06"
+LBC_SPEC_INTVL_HRS="3"
+
+DATE_FIRST_CYCL="20200801"
+DATE_LAST_CYCL="20200801"
+CYCL_HRS=( "00" )
+
+EXTRN_MDL_NAME_ICS="HRRRX"
+EXTRN_MDL_NAME_LBCS="RAPX"
+
+#
+# In NCO mode, the following don't need to be explicitly set to "FALSE"
+# in this configuration file because the experiment generation script
+# will do this (along with printing out an informational message).
+#
+#RUN_TASK_MAKE_GRID="FALSE"
+#RUN_TASK_MAKE_OROG="FALSE"
+#RUN_TASK_MAKE_SFC_CLIMO="FALSE"
+
+#
+# In order to prevent simultaneous WE2E (Workflow End-to-End) tests that
+# are running in NCO mode and which run the same cycles from interfering
+# with each other, for each cycle, each such test must have a distinct
+# path to the following two directories:
+#
+# 1) The directory in which the cycle-dependent model input files, symlinks
+#    to cycle-independent input files, and raw (i.e. before post-processing)
+#    forecast output files for a given cycle are stored.  The path to this
+#    directory is
+#
+#      $STMP/tmpnwprd/$RUN/$cdate
+#
+#    where cdate is the starting year (yyyy), month (mm), day (dd) and
+#    hour of the cycle in the form yyyymmddhh.
+#
+# 2) The directory in which the output files from the post-processor (UPP)
+#    for a given cycle are stored.  The path to this directory is
+#
+#      $PTMP/com/$NET/$envir/$RUN.$yyyymmdd/$hh
+#
+# Here, we make the first directory listed above unique to a WE2E test
+# by setting RUN to the name of the current test.  This will also make
+# the second directory unique because it also conains the variable RUN
+# in its full path, but if this directory -- or set of directories since
+# it involves a set of cycles and forecast hours -- already exists from
+# a previous run of the same test, then it is much less confusing to the
+# user to first move or delete this set of directories during the workflow
+# generation step and then start the experiment (whether we move or delete
+# depends on the setting of PREEXISTING_DIR_METHOD).  For this purpose,
+# it is most convenient to put this set of directories under an umbrella
+# directory that has the same name as the experiment.  This can be done
+# by setting the variable envir to the name of the current test.  Since
+# as mentiond above we will store this name in RUN, below we simply set
+# envir to RUN.  Then, for this test, the UPP output will be located in
+# the directory
+#
+#   $PTMP/com/$NET/$RUN/$RUN.$yyyymmdd/$hh
+#
+# Note that by the time this file is sourced by the experiment generation
+# script, the script that launces the WE2E test experiments will have 
+# filled in the value of the variable EXPT_SUBDIR above (which contains 
+# the name of the experiment).  Thus, below, we can assume that EXPT_SUBDIR
+# has a valid value and use it to set RUN and envir.
+#
+RUN="${EXPT_SUBDIR}"
+envir="${EXPT_SUBDIR}"
+
+#
+# In NCO mode, the user must manually (e.g. after doing the build step)
+# create the symlink "${FIXrrfs}/fix_sar" that points to EMC's FIXsar
+# directory on the machine.  For example, on hera, the symlink's target
+# needs to be
+#
+#   /scratch2/NCEPDEV/fv3-cam/emc.campara/fix_fv3cam/fix_sar
+#
+# The experiment generation script will then set FIXsar to
+#
+#   FIXsar="${FIXrrfs}/fix_sar/${EMC_GRID_NAME}"
+#
+# where EMC_GRID_NAME has the value set above.
+#
+

--- a/tests/baseline_configs/config.nco_GSD_SUBCONUS3km_HRRRX_RAPX.sh
+++ b/tests/baseline_configs/config.nco_GSD_SUBCONUS3km_HRRRX_RAPX.sh
@@ -1,0 +1,111 @@
+#
+# The values of the variables MACHINE, ACCOUNT, and EXPT_SUBDIR are required
+# inputs to the script that launces the WE2E test experiments.  That script 
+# will use those inputs to fill in the values of these variables below.
+#
+MACHINE=""
+ACCOUNT=""
+EXPT_SUBDIR=""
+#
+# The values of the variables USE_CRON_TO_RELAUNCH and CRON_RELAUNCH_INTVL_MNTS
+# are optional inputs to the script that launces the WE2E test experiments.  
+# If one or both of these values are specified, then that script will 
+# replace the default values of these variables below with those values.
+# Otherwise, it will keep the default values.
+#
+USE_CRON_TO_RELAUNCH="TRUE"
+CRON_RELAUNCH_INTVL_MNTS="02"
+
+VERBOSE="TRUE"
+
+RUN_ENVIR="nco"
+PREEXISTING_DIR_METHOD="rename"
+
+EMC_GRID_NAME="GSD_SUBCONUS3km"
+GRID_GEN_METHOD="ESGgrid"
+
+QUILTING="TRUE"
+USE_CCPP="TRUE"
+CCPP_PHYS_SUITE="FV3_GSD_SAR"
+FCST_LEN_HRS="06"
+LBC_SPEC_INTVL_HRS="3"
+
+DATE_FIRST_CYCL="20200801"
+DATE_LAST_CYCL="20200801"
+CYCL_HRS=( "00" )
+
+EXTRN_MDL_NAME_ICS="HRRRX"
+EXTRN_MDL_NAME_LBCS="RAPX"
+
+#
+# In NCO mode, the following don't need to be explicitly set to "FALSE"
+# in this configuration file because the experiment generation script
+# will do this (along with printing out an informational message).
+#
+#RUN_TASK_MAKE_GRID="FALSE"
+#RUN_TASK_MAKE_OROG="FALSE"
+#RUN_TASK_MAKE_SFC_CLIMO="FALSE"
+
+#
+# In order to prevent simultaneous WE2E (Workflow End-to-End) tests that
+# are running in NCO mode and which run the same cycles from interfering
+# with each other, for each cycle, each such test must have a distinct
+# path to the following two directories:
+#
+# 1) The directory in which the cycle-dependent model input files, symlinks
+#    to cycle-independent input files, and raw (i.e. before post-processing)
+#    forecast output files for a given cycle are stored.  The path to this
+#    directory is
+#
+#      $STMP/tmpnwprd/$RUN/$cdate
+#
+#    where cdate is the starting year (yyyy), month (mm), day (dd) and
+#    hour of the cycle in the form yyyymmddhh.
+#
+# 2) The directory in which the output files from the post-processor (UPP)
+#    for a given cycle are stored.  The path to this directory is
+#
+#      $PTMP/com/$NET/$envir/$RUN.$yyyymmdd/$hh
+#
+# Here, we make the first directory listed above unique to a WE2E test
+# by setting RUN to the name of the current test.  This will also make
+# the second directory unique because it also conains the variable RUN
+# in its full path, but if this directory -- or set of directories since
+# it involves a set of cycles and forecast hours -- already exists from
+# a previous run of the same test, then it is much less confusing to the
+# user to first move or delete this set of directories during the workflow
+# generation step and then start the experiment (whether we move or delete
+# depends on the setting of PREEXISTING_DIR_METHOD).  For this purpose,
+# it is most convenient to put this set of directories under an umbrella
+# directory that has the same name as the experiment.  This can be done
+# by setting the variable envir to the name of the current test.  Since
+# as mentiond above we will store this name in RUN, below we simply set
+# envir to RUN.  Then, for this test, the UPP output will be located in
+# the directory
+#
+#   $PTMP/com/$NET/$RUN/$RUN.$yyyymmdd/$hh
+#
+# Note that by the time this file is sourced by the experiment generation
+# script, the script that launces the WE2E test experiments will have 
+# filled in the value of the variable EXPT_SUBDIR above (which contains 
+# the name of the experiment).  Thus, below, we can assume that EXPT_SUBDIR
+# has a valid value and use it to set RUN and envir.
+#
+RUN="${EXPT_SUBDIR}"
+envir="${EXPT_SUBDIR}"
+
+#
+# In NCO mode, the user must manually (e.g. after doing the build step)
+# create the symlink "${FIXrrfs}/fix_sar" that points to EMC's FIXsar
+# directory on the machine.  For example, on hera, the symlink's target
+# needs to be
+#
+#   /scratch2/NCEPDEV/fv3-cam/emc.campara/fix_fv3cam/fix_sar
+#
+# The experiment generation script will then set FIXsar to
+#
+#   FIXsar="${FIXrrfs}/fix_sar/${EMC_GRID_NAME}"
+#
+# where EMC_GRID_NAME has the value set above.
+#
+

--- a/tests/baselines_list.txt
+++ b/tests/baselines_list.txt
@@ -2,6 +2,7 @@ FV3_RRFS_v1beta
 GSD_RAP13km
 community_ensemble_008mems
 community_ensemble_2mems
+nco_GSD_SUBCONUS3km_HRRRX_RAPX
 nco_GSD_HRRR3km_FV3GFS_FV3GFS
 nco_GSD_HRRR3km_HRRRX_RAPX
 nco_conus

--- a/ush/set_predef_grid_params.sh
+++ b/ush/set_predef_grid_params.sh
@@ -522,6 +522,63 @@ predefined domain:
 #
 #-----------------------------------------------------------------------
 #
+# GSD's sub-CONUS domain with ~3km cells.
+#
+#-----------------------------------------------------------------------
+#
+"GSD_SUBCONUS3km")
+
+  if [ "${GRID_GEN_METHOD}" = "GFDLgrid" ]; then
+
+    print_err_msg_exit "\
+The parameters for a \"${GRID_GEN_METHOD}\" type grid have not yet been specified for this
+predefined domain:
+  PREDEF_GRID_NAME = \"${PREDEF_GRID_NAME}\"
+  GRID_GEN_METHOD = \"${GRID_GEN_METHOD}\""
+
+  elif [ "${GRID_GEN_METHOD}" = "ESGgrid" ]; then
+
+    ESGgrid_LON_CTR=-97.5
+    ESGgrid_LAT_CTR=35.0
+
+    ESGgrid_DELX="3000.0"
+    ESGgrid_DELY="3000.0"
+
+    ESGgrid_NX=840
+    ESGgrid_NY=600
+
+    ESGgrid_WIDE_HALO_WIDTH=6
+
+    DT_ATMOS="40"
+
+#    LAYOUT_X="12"
+#    LAYOUT_Y="10"
+#    BLOCKSIZE="30"
+    LAYOUT_X="30"
+    LAYOUT_Y="24"
+    BLOCKSIZE="35"
+
+    if [ "$QUILTING" = "TRUE" ]; then
+      WRTCMP_write_groups="1"
+      WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+      WRTCMP_output_grid="lambert_conformal"
+      WRTCMP_cen_lon="${ESGgrid_LON_CTR}"
+      WRTCMP_cen_lat="${ESGgrid_LAT_CTR}"
+      WRTCMP_stdlat1="${ESGgrid_LAT_CTR}"
+      WRTCMP_stdlat2="${ESGgrid_LAT_CTR}"
+      WRTCMP_nx="825"
+      WRTCMP_ny="580"
+      WRTCMP_lon_lwr_left="-109.8"
+      WRTCMP_lat_lwr_left="26.5"
+      WRTCMP_dx="${ESGgrid_DELX}"
+      WRTCMP_dy="${ESGgrid_DELY}"
+    fi
+
+  fi
+  ;;
+#
+#-----------------------------------------------------------------------
+#
 # EMC's 3km CONUS grid.
 #
 #-----------------------------------------------------------------------

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -459,10 +459,10 @@ case "${EMC_GRID_NAME}" in
   "conus_c96")
     PREDEF_GRID_NAME="EMC_CONUS_coarse"
     ;;
-  "GSD_HRRR3km")
+  "GSD_HRRR25km" | "GSD_HRRR13km" | "GSD_HRRR3km" | "GSD_SUBCONUS3km")
     PREDEF_GRID_NAME="${EMC_GRID_NAME}"
     ;;
-  "conus_orig"|"guam"|"hi"|"pr")
+  "conus_orig" | "guam" | "hi" | "pr")
     print_err_msg_exit "\
 A predefined grid (PREDEF_GRID_NAME) has not yet been defined for this
 EMC grid (EMC_GRID_NAME):

--- a/ush/valid_param_vals.sh
+++ b/ush/valid_param_vals.sh
@@ -14,11 +14,26 @@ valid_vals_PREDEF_GRID_NAME=( \
 "GSD_HAFSV0.A25km" \
 "GSD_RRFSAK_3km" \
 "GSD_HRRR_AK_50km" \
-"GSD_HRRR3km" \
-"GSD_HRRR13km" \
 "GSD_HRRR25km" \
-"GSD_RAP13km" )
-valid_vals_EMC_GRID_NAME=("ak" "conus" "conus_c96" "conus_orig" "guam" "hi" "pr" "GSD_HRRR3km")
+"GSD_HRRR13km" \
+"GSD_HRRR3km" \
+"GSD_SUBCONUS3km" \
+"GSD_RAP13km" \
+)
+valid_vals_EMC_GRID_NAME=( \
+"ak" \
+"conus" \
+"conus_c96" \
+"conus_orig" \
+"guam" \
+"hi" \
+"pr" \
+"GSD_HRRR25km" \
+"GSD_HRRR13km" \
+"GSD_HRRR3km" \
+"GSD_SUBCONUS3km" \
+"GSD_RAP13km" \
+)
 valid_vals_USE_CCPP=("TRUE" "true" "YES" "yes" "FALSE" "false" "NO" "no")
 valid_vals_CCPP_PHYS_SUITE=( \
 "FV3_CPT_v0" \
@@ -28,7 +43,8 @@ valid_vals_CCPP_PHYS_SUITE=( \
 "FV3_GSD_v0" \
 "FV3_GFS_v15p2" \
 "FV3_GFS_v16beta" \
-"FV3_RRFS_v1beta" ) 
+"FV3_RRFS_v1beta" \
+) 
 valid_vals_OZONE_PARAM_NO_CCPP=("ozphys_2015" "ozphys")
 valid_vals_GFDLgrid_RES=("48" "96" "192" "384" "768" "1152" "3072")
 valid_vals_EXTRN_MDL_NAME_ICS=("GSMGFS" "FV3GFS" "RAPX" "HRRRX")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
* Add new subconus 3km grid of ESGgrid type named GSD_SUBCONUS3km.
* Allow this as well as the GSD_HRRR25km, GSD_HRRR13km, and GSD_RAP13km grids to run in NCO mode.
* Add new WE2E test for the GSD_SUBCONUS3km grid in NCO mode named nco_GSD_SUBCONUS3km_HRRRX_RAPX.
* Add new WE2E test for the GSD_HRRR25km grid in NCO mode named nco_GSD_HRRR25km_HRRRX_RAPX.

## TESTS CONDUCTED: 
Ran the two new WE2E tests on hera -- nco_GSD_SUBCONUS3km_HRRRX_RAPX and nco_GSD_HRRR25km_HRRRX_RAPX.  Both completed successfully.  The changes do not affect any of the other WE2E tests, so those were not run.

