### PR TITLE
Wrapped global_equiv_resol exec_fp with APRUN just as other commands …

### DIFF
--- a/scripts/exregional_make_grid.sh
+++ b/scripts/exregional_make_grid.sh
@@ -429,7 +429,7 @@ cubed-sphere grid equivalent resolution does not exist:
 Please ensure that you've built this executable."
 fi
 
-${exec_fp} "${grid_fp}" || \
+$APRUN ${exec_fp} "${grid_fp}" || \
 print_err_msg_exit "\
 Call to executable (exec_fp) that calculates the regional grid's global
 uniform cubed-sphere grid equivalent resolution returned with nonzero exit

--- a/ush/get_extrn_mdl_file_dir_info.sh
+++ b/ush/get_extrn_mdl_file_dir_info.sh
@@ -603,6 +603,9 @@ has not been specified for this external model and machine combination:
     "CHEYENNE")
       sysdir="$sysbasedir/gfs.${yyyymmdd}/${hh}"
       ;;
+    "STAMPEDE")
+      sysdir="$sysbasedir"
+      ;;
     *)
       print_err_msg_exit "\
 The system directory in which to look for external model output files 

--- a/ush/set_extrn_mdl_params.sh
+++ b/ush/set_extrn_mdl_params.sh
@@ -95,6 +95,9 @@ else
     "ODIN")
       EXTRN_MDL_SYSBASEDIR_ICS="/scratch/ywang/test_runs/FV3_regional/gfs"
       ;;
+    "STAMPEDE")
+      EXTRN_MDL_SYSBASEDIR_ICS="/scratch/00315/tg455890/GDAS/20190530/2019053000_mem001"
+      ;;
     "CHEYENNE")
       EXTRN_MDL_SYSBASEDIR_ICS="/glade/p/ral/jntp/UFS_CAM/COMGFS"
       ;;
@@ -239,6 +242,9 @@ else
       ;;
     "CHEYENNE")
       EXTRN_MDL_SYSBASEDIR_LBCS="/glade/p/ral/jntp/UFS_CAM/COMGFS"
+      ;;
+    "STAMPEDE")
+      EXTRN_MDL_SYSBASEDIR_LBCS="/scratch/00315/tg455890/GDAS/20190530/2019053000_mem001"
       ;;
     esac
     ;;


### PR DESCRIPTION
Wrapped global_equiv_resol exec_fp with APRUN just as other commands do and inserted CASE statements for Stampede.

- in scripts/exregional_make_grid.sh, added "$APRUN" before "${exec_fp}" for "global_equiv_resol". This is to make sure the command "global_equiv_resol" will be executed on compute nodes just as other commands do. I am not sure why "$APRUN" is missed for "global_equiv_resol" only. Otherwise, the command will fail on Odin.

- Added platform support for "STAMPEDE" in some CASE statements in _ush/get_extrn_mdl_file_dir_info.sh_ & _ush/set_extrn_mdl_params.sh_.
