### PR TITLE
Modifications to run workflow with unmodified executable names from each repository

### DIFF
--- a/scripts/exregional_make_grid.sh
+++ b/scripts/exregional_make_grid.sh
@@ -513,7 +513,7 @@ fi
 #
 # Set the name and path to the executable and make sure that it exists.
 #
-exec_fn="shave.x"
+exec_fn="shave"
 exec_fp="$EXECDIR/${exec_fn}"
 if [ ! -f "${exec_fp}" ]; then
   print_err_msg_exit "\

--- a/scripts/exregional_make_ics.sh
+++ b/scripts/exregional_make_ics.sh
@@ -493,7 +493,7 @@ hh="${EXTRN_MDL_CDATE:8:2}"
 #
 #-----------------------------------------------------------------------
 #
-exec_fn="chgres_cube.exe"
+exec_fn="chgres_cube"
 exec_fp="$EXECDIR/${exec_fn}"
 if [ ! -f "${exec_fp}" ]; then
   print_err_msg_exit "\

--- a/scripts/exregional_make_lbcs.sh
+++ b/scripts/exregional_make_lbcs.sh
@@ -344,7 +344,7 @@ esac
 #
 #-----------------------------------------------------------------------
 #
-exec_fn="chgres_cube.exe"
+exec_fn="chgres_cube"
 exec_fp="$EXECDIR/${exec_fn}"
 if [ ! -f "${exec_fp}" ]; then
   print_err_msg_exit "\

--- a/scripts/exregional_make_orog.sh
+++ b/scripts/exregional_make_orog.sh
@@ -181,7 +181,7 @@ mkdir_vrfy -p "${shave_dir}"
 # Set the name and path to the executable that generates the raw orography
 # file and make sure that it exists.
 #
-exec_fn="orog.x"
+exec_fn="orog"
 exec_fp="$EXECDIR/${exec_fn}"
 if [ ! -f "${exec_fp}" ]; then
   print_err_msg_exit "\
@@ -531,7 +531,7 @@ Filtering of orography complete."
 #
 # Set the name and path to the executable and make sure that it exists.
 #
-exec_fn="shave.x"
+exec_fn="shave"
 exec_fp="$EXECDIR/${exec_fn}"
 if [ ! -f "${exec_fp}" ]; then
   print_err_msg_exit "\

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -165,7 +165,7 @@ forecast hour directory (fhr_dir):
 fi
 cp_vrfy ${post_config_fp} ./postxconfig-NT.txt
 cp_vrfy ${EMC_POST_DIR}/parm/params_grib2_tbl_new ./params_grib2_tbl_new
-cp_vrfy ${EXECDIR}/nceppost.x .
+cp_vrfy ${EXECDIR}/ncep_post .
 #
 #-----------------------------------------------------------------------
 #
@@ -214,7 +214,7 @@ EOF
 #
 #-----------------------------------------------------------------------
 #
-${APRUN} ./nceppost.x < itag || print_err_msg_exit "\
+${APRUN} ./ncep_post < itag || print_err_msg_exit "\
 Call to executable to run post for forecast hour $fhr returned with non-
 zero exit code."
 #

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -165,7 +165,7 @@ forecast hour directory (fhr_dir):
 fi
 cp_vrfy ${post_config_fp} ./postxconfig-NT.txt
 cp_vrfy ${EMC_POST_DIR}/parm/params_grib2_tbl_new ./params_grib2_tbl_new
-cp_vrfy ${EXECDIR}/ncep_post .
+cp_vrfy ${EXECDIR}/nceppost.x .
 #
 #-----------------------------------------------------------------------
 #
@@ -214,7 +214,7 @@ EOF
 #
 #-----------------------------------------------------------------------
 #
-${APRUN} ./ncep_post < itag || print_err_msg_exit "\
+${APRUN} ./nceppost.x < itag || print_err_msg_exit "\
 Call to executable to run post for forecast hour $fhr returned with non-
 zero exit code."
 #

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -600,13 +600,14 @@ fi
 exec_fp="${SR_WX_APP_TOP_DIR}/bin/${exec_fn}"
 #Check for the old build location for fv3 executable
 if [ ! -f "${exec_fp}" ]; then
-  if [ ! -f "${SR_WX_APP_TOP_DIR}/src/ufs_weather_model/build/${exec_fn}" ]; then
-  print_err_msg_exit "\
+  exec_fp_alt="${UFS_WTHR_MDL_DIR}/build/${exec_fn}"
+  if [ ! -f "${exec_fp_alt}" ]; then
+    print_err_msg_exit "\
 The executable (exec_fp) for running the forecast model does not exist:
   exec_fp = \"${exec_fp}\"
 Please ensure that you've built this executable."
   else
-    exec_fp="${SR_WX_APP_TOP_DIR}/src/ufs_weather_model/build/${exec_fn}"
+    exec_fp="${exec_fp_alt}"
   fi
 fi
 

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -598,6 +598,18 @@ Please set USE_CCPP=TRUE in your config.sh file.
 fi
 
 exec_fp="${SR_WX_APP_TOP_DIR}/bin/${exec_fn}"
+#Check for the old build location for fv3 executable
+if [ ! -f "${exec_fp}" ]; then
+  if [ ! -f "${SR_WX_APP_TOP_DIR}/src/ufs_weather_model/build/${exec_fn}" ]; then
+  print_err_msg_exit "\
+The executable (exec_fp) for running the forecast model does not exist:
+  exec_fp = \"${exec_fp}\"
+Please ensure that you've built this executable."
+  else
+    exec_fp="${SR_WX_APP_TOP_DIR}/src/ufs_weather_model/build/${exec_fn}"
+  fi
+fi
+
 if [ ! -f "${exec_fp}" ]; then
   print_err_msg_exit "\
 The executable (exec_fp) for running the forecast model does not exist:

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -589,12 +589,15 @@ fi
 #-----------------------------------------------------------------------
 #
 if [ "${USE_CCPP}" = "TRUE" ]; then
-  exec_fn="fv3.exe"
+  exec_fn="NEMS.exe"
 else
-  exec_fn="fv3_32bit.exe"
+    print_err_msg_exit "\
+Running this workflow without CCPP is not supported at this time.
+Please set USE_CCPP=TRUE in your config.sh file.
+"
 fi
 
-exec_fp="${UFS_WTHR_MDL_DIR}/tests/${exec_fn}"
+exec_fp="${SR_WX_APP_TOP_DIR}/bin/${exec_fn}"
 if [ ! -f "${exec_fp}" ]; then
   print_err_msg_exit "\
 The executable (exec_fp) for running the forecast model does not exist:

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -715,7 +715,7 @@ SORCDIR="$HOMErrfs/sorc"
 SRC_DIR="${SR_WX_APP_TOP_DIR}/src"
 PARMDIR="$HOMErrfs/parm"
 MODULES_DIR="$HOMErrfs/modulefiles"
-EXECDIR="${SR_WX_APP_TOP_DIR}/exec"
+EXECDIR="${SR_WX_APP_TOP_DIR}/bin"
 FIXrrfs="$HOMErrfs/fix"
 TEMPLATE_DIR="$USHDIR/templates"
 


### PR DESCRIPTION
# Note: This PR must be merged at the same time as [SRW App PR#27](https://github.com/ufs-community/ufs-srweather-app/pull/27)

## DESCRIPTION OF CHANGES: 
The new top-level cmake build for the SRW App ([SRW App PR#27](https://github.com/ufs-community/ufs-srweather-app/pull/27)) results in some executables having different names. This PR makes modifications that
 1. Allow the workflow to run successfully with the new cmake build and its different executable names, and
 2. Allow back-compatibility with the old build system to allow for a gradual transition to new build system

This PR also explicitly disallows running the workflow without CCPP, which we decided against supporting several months ago. I don't think the capability even works so this shouldn't effect anyone at this time.

## TESTS CONDUCTED: 
 - **Cheyenne**: Build and end-to-end test ("DOT_OR_USCORE" test case) was successful on Cheyenne with intel, both for the cmake build and the old build script (that will soon be deprecated). Path to tests: /glade/scratch/kavulich/UFS_CAM/testing/SRW_PR_27/expt_dirs/
 - **Hera**: Build and end-to-end tests successful (aside from expected failures). Path to tests: /scratch2/BMC/det/kavulich/workdir/SRW_PR_27/expt_dirs
   - ~~Currently debugging end-to-end tests on Hera; there is some kind of library problem related to the latest ufs-weather-model commit (https://github.com/ufs-community/ufs-weather-model/commit/f68dcdb8bc80a898de7a7ef3492da0cd633dcd4f)~~ Fixed
 - **Jet**: Build test was successful. Machine is having disk errors that are preventing me from running the end-to-end tests.

## ISSUE: 
It was not the primary aim of this PR, but it does partially resolve #196 

