### PR TITLE
Apply PR #322 to develop

### DIFF
--- a/scripts/exregional_make_orog.sh
+++ b/scripts/exregional_make_orog.sh
@@ -363,25 +363,6 @@ mv_vrfy "${raw_orog_fp_orig}" "${raw_orog_fp}"
 #
 #-----------------------------------------------------------------------
 #
-# Copy the two orography files needed for the drag suite in the FV3_RRFS_v1beta
-# physics suite.
-# 
-# Note that the following is a temporary fix. We need a long-term solution 
-# that calls a script or program to generates the necessary files (instead 
-# of copying them).
-#
-#-----------------------------------------------------------------------
-#
-if [ "${CCPP_PHYS_SUITE}" = "FV3_RRFS_v1beta" ]; then
-  cp_vrfy ${GWD_RRFS_v1beta_DIR}/*_ls*.nc ${OROG_DIR}
-  cp_vrfy ${GWD_RRFS_v1beta_DIR}/*_ss*.nc ${OROG_DIR}
-fi
-
-print_info_msg "$VERBOSE" "
-Orography file generation complete."
-#
-#-----------------------------------------------------------------------
-#
 # Note that the orography filtering code assumes that the regional grid
 # is a GFDLgrid type of grid; it is not designed to handle ESGgrid type
 # regional grids.  If the flag "regional" in the orography filtering 

--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -254,36 +254,6 @@ Cannot create symlink because target does not exist:
   target = \"$target\""
 fi
 #
-# If using the FV3_RRFS_v1beta physics suite, there are two files (that
-# contain statistics of the orography) that are needed by the drag
-# parameterization in that suite.  Below, symlinks to these are created
-# in the run directory.  Note that the symlinks must have specific names
-# that the FV3 model is hardcoded to recognize ("${CRES}_" and "halo0"
-# must be stripped from the file names).  We use those below.
-#
-if [ "${CCPP_PHYS_SUITE}" = "FV3_RRFS_v1beta" ]; then
-# Symlink to orographic statistics fields file with "${CRES}_" and "halo0"
-# stripped from name.
-  target="${FIXLAM}/${CRES}${DOT_OR_USCORE}oro_data_ls.tile${TILE_RGNL}.halo${NH0}.nc"
-  symlink="oro_data_ls.nc"
-  if [ -f "${target}" ]; then
-    ln_vrfy -sf ${relative_or_null} $target $symlink
-  else
-    print_err_msg_exit "\
-Cannot create symlink because target does not exist:
-  target = \"$target}\""
-  fi
-  target="${FIXLAM}/${CRES}${DOT_OR_USCORE}oro_data_ss.tile${TILE_RGNL}.halo${NH0}.nc"
-  symlink="oro_data_ss.nc"
-  if [ -f "${target}" ]; then
-    ln_vrfy -sf ${relative_or_null} $target $symlink
-  else
-    print_err_msg_exit "\
-Cannot create symlink because target does not exist:
-  target = \"$target}\""
-  fi
-fi
-#
 # Symlink to halo-4 orography file with "${CRES}_" stripped from name.
 #
 # If this link is not created, then the code hangs with an error message

--- a/tests/run_experiments.sh
+++ b/tests/run_experiments.sh
@@ -579,41 +579,6 @@ SFC_CLIMO_DIR=\"${SFC_CLIMO_DIR}\""
 #
 #-----------------------------------------------------------------------
 #
-# If using the FV3_RRFS_v1beta physics suite, set the base directory in 
-# which the pregenerated orography statistics files needed by the gravity 
-# wave drag parameterization in this suite are located.
-#
-#-----------------------------------------------------------------------
-#
-  if [ "${CCPP_PHYS_SUITE}" = "FV3_RRFS_v1beta" ]; then
-
-    if [ "$MACHINE" = "HERA" ]; then
-      GWD_RRFS_v1beta_BASEDIR="/scratch2/BMC/det/FV3LAM_pregen/orog"
-    elif [ "$MACHINE" = "JET" ]; then
-      GWD_RRFS_v1beta_BASEDIR="/lfs4/BMC/wrfruc/FV3LAM_pregen/orog"
-    elif [ "$MACHINE" = "CHEYENNE" ]; then
-      GWD_RRFS_v1beta_BASEDIR="/glade/p/ral/jntp/UFS_CAM/FV3LAM_pregen/orog"
-    else
-      print_err_msg_exit "\
-The base directory (GWD_RRFS_v1beta_BASEDIR) containing the pregenerated 
-orography statistics files needed by the gravity wave drag parameterization
-in the FV3_RRFS_v1beta physics suite has not been specified for this 
-machine (MACHINE):
-  MACHINE= \"${MACHINE}\""
-    fi
-
-    str=${str}"
-#
-# Base directory containing the pregenerated orography statistics files 
-# needed by the gravity wave drag parameterization in the FV3_RRFS_v1beta 
-# physics suite.
-#
-GWD_RRFS_v1beta_BASEDIR=\"${GWD_RRFS_v1beta_BASEDIR}\""
-
-  fi
-#
-#-----------------------------------------------------------------------
-#
 #
 #
 #-----------------------------------------------------------------------

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -1238,26 +1238,6 @@ HALO_BLEND=0
 #
 #-----------------------------------------------------------------------
 #
-# GWD_RRFS_v1beta_BASEDIR:
-# Temporary workflow variable specifies the base directory in which to 
-# look for certain fixed orography files needed only by the gravity wave 
-# drag parameterization in the FV3_RRFS_v1beta physics suite.  This variable
-# is added in order to avoid including hard-coded paths in the workflow
-# scripts.  Currently, the workflow simply copies the necessary files 
-# from a subdirectory under this directory (named according to the specified
-# predefined grid) to the orography directory (OROG_DIR) under the 
-# experiment directory.  
-#
-# Note that this variable is only used when using the FV3_RRFS_v1beta 
-# physics suite.  This variable should be removed from the workflow once 
-# there is a script that generates these files for any grid.
-#
-#-----------------------------------------------------------------------
-#
-GWD_RRFS_v1beta_BASEDIR=""
-#
-#-----------------------------------------------------------------------
-#
 # USE_FVCOM:
 # Flag set to update surface conditions in FV3-LAM with fields generated
 # from the Finite Volume Community Ocean Model (FVCOM). This will

--- a/ush/link_fix.sh
+++ b/ush/link_fix.sh
@@ -245,13 +245,6 @@ Creating links in the FIXLAM directory to the grid files..."
     "C*${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo${NH0}.nc" \
     "C*${DOT_OR_USCORE}oro_data.tile${TILE_RGNL}.halo${NH4}.nc" \
         )
-    if [ "${CCPP_PHYS_SUITE}" = "FV3_RRFS_v1beta" ]; then
-      fns+=( \
-      "C*${DOT_OR_USCORE}oro_data_ss.tile${TILE_RGNL}.halo${NH0}.nc" \
-      "C*${DOT_OR_USCORE}oro_data_ls.tile${TILE_RGNL}.halo${NH0}.nc" \
-           )
-    fi
-
     fps=( "${fns[@]/#/${OROG_DIR}/}" )
     run_task="${RUN_TASK_MAKE_OROG}"
     ;;

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -930,40 +930,6 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-# If using the FV3_RRFS_v1beta physics suite, make sure that the directory
-# from which certain fixed orography files will be copied to the experiment 
-# directory actually exists.  Note that this is temporary code.  It should
-# be removed once there is a script that will create these orography files
-# for any grid.
-#
-#-----------------------------------------------------------------------
-#
-GWD_RRFS_v1beta_DIR="${GWD_RRFS_v1beta_BASEDIR}/${PREDEF_GRID_NAME}"
-if [ "${CCPP_PHYS_SUITE}" = "FV3_RRFS_v1beta" ]; then
-  if [ -z "${PREDEF_GRID_NAME}" ]; then
-    print_err_msg_exit "\
-A predefined grid name (PREDEF_GRID_NAME) must be specified when using 
-the FV3_RRFS_v1beta physic suite:
-  CCPP_PHYS_SUITE = \"${CCPP_PHYS_SUITE}\"
-  PREDEF_GRID_NAME = \"${PREDEF_GRID_NAME}\""
-  else        
-    if [ ! -d "${GWD_RRFS_v1beta_DIR}" ]; then
-      print_err_msg_exit "\
-The directory (GWD_RRFS_v1beta_DIR) that should contain the gravity wave 
-drag-related orography files for the FV3_RRFS_v1beta does not exist:
-  GWD_RRFS_v1beta_DIR = \"${GWD_RRFS_v1beta_DIR}\""
-    elif [ ! "$( ls -A ${GWD_RRFS_v1beta_DIR} )" ]; then
-      print_err_msg_exit "\
-The directory (GWD_RRFS_v1beta_DIR) that should contain the gravity wave 
-drag related orography files for the FV3_RRFS_v1beta is empty:
-  GWD_RRFS_v1beta_DIR = \"${GWD_RRFS_v1beta_DIR}\""
-    fi      
-  fi
-fi
-#
-#
-#-----------------------------------------------------------------------
-#
 # If the base directory (EXPT_BASEDIR) in which the experiment subdirectory 
 # (EXPT_SUBDIR) will be located does not start with a "/", then it is 
 # either set to a null string or contains a relative directory.  In both 
@@ -2473,7 +2439,6 @@ CYCLE_BASEDIR="${CYCLE_BASEDIR}"
 GRID_DIR="${GRID_DIR}"
 OROG_DIR="${OROG_DIR}"
 SFC_CLIMO_DIR="${SFC_CLIMO_DIR}"
-GWD_RRFS_v1beta_DIR="${GWD_RRFS_v1beta_DIR}"
 
 NDIGITS_ENSMEM_NAMES="${NDIGITS_ENSMEM_NAMES}"
 ENSMEM_NAMES=( $( printf "\"%s\" " "${ENSMEM_NAMES[@]}" ))

--- a/ush/templates/FV3.input.yml
+++ b/ush/templates/FV3.input.yml
@@ -54,7 +54,6 @@ FV3_RRFS_v1beta:
     imfshalcnv: -1
     IMFDEEPCNV: -1
     DO_MYNNSFCLAY: true
-    GWD_OPT: 3
     do_deep: False
   atmos_model_nml:
     fdiag: 3


### PR DESCRIPTION
## DESCRIPTION OF CHANGES:
Removed checks on the RRFS_v1beta SDF implemented for use with the GSL GWD suite (now uses the GFS GWD suite).  No longer copies staged orography files necessary for the GSL GWD suite.

## TESTS CONDUCTED:
End-to-end runs DOT_OR_USCORE, suite_FV3_GFS_v15p2, and suite_FV3_RRFS_v1beta succeeded on Cheyenne.

## ISSUE: 
Related to https://github.com/NOAA-EMC/regional_workflow/pull/322

## CONTRIBUTORS (optional): 
Original author: JeffBeck-NOAA <jeff.beck@noaa.gov>
