### PR TITLE
Add Thompson ice- and water-friendly aerosol climo file support

### DIFF
--- a/ush/set_thompson_mp_fix_files.sh
+++ b/ush/set_thompson_mp_fix_files.sh
@@ -123,6 +123,14 @@ string."
       "qr_acr_qs.dat" \
       )
 
+    if [ "${EXTRN_MDL_NAME_ICS}" != "HRRRX" ] && \
+       [ "${EXTRN_MDL_NAME_ICS}" != "RAPX" ] && \
+       [ "${EXTRN_MDL_NAME_LBCS}" != "HRRRX" ] && \
+       [ "${EXTRN_MDL_NAME_LBCS}" != "RAPX" ]; then
+      thompson_mp_fix_files+=( "Thompson_MP_MONTHLY_CLIMO.nc" )
+    fi
+
+
     FIXgsm_FILES_TO_COPY_TO_FIXam+=( "${thompson_mp_fix_files[@]}" )
 
     num_files=${#thompson_mp_fix_files[@]} 

--- a/ush/set_thompson_mp_fix_files.sh
+++ b/ush/set_thompson_mp_fix_files.sh
@@ -123,13 +123,10 @@ string."
       "qr_acr_qs.dat" \
       )
 
-    if [ "${EXTRN_MDL_NAME_ICS}" != "HRRRX" ] && \
-       [ "${EXTRN_MDL_NAME_ICS}" != "RAPX" ] && \
-       [ "${EXTRN_MDL_NAME_LBCS}" != "HRRRX" ] && \
-       [ "${EXTRN_MDL_NAME_LBCS}" != "RAPX" ]; then
+    if [ "${EXTRN_MDL_NAME_ICS}" != "HRRRX" -a "${EXTRN_MDL_NAME_ICS}" != "RAPX" ] || \
+       [ "${EXTRN_MDL_NAME_LBCS}" != "HRRRX" -a "${EXTRN_MDL_NAME_LBCS}" != "RAPX" ]; then
       thompson_mp_fix_files+=( "Thompson_MP_MONTHLY_CLIMO.nc" )
-    fi
-
+    fi  
 
     FIXgsm_FILES_TO_COPY_TO_FIXam+=( "${thompson_mp_fix_files[@]}" )
 

--- a/ush/set_thompson_mp_fix_files.sh
+++ b/ush/set_thompson_mp_fix_files.sh
@@ -122,10 +122,13 @@ string."
       "qr_acr_qg.dat" \
       "qr_acr_qs.dat" \
       )
+   
 
     if [ "${EXTRN_MDL_NAME_ICS}" != "HRRRX" -a "${EXTRN_MDL_NAME_ICS}" != "RAPX" ] || \
        [ "${EXTRN_MDL_NAME_LBCS}" != "HRRRX" -a "${EXTRN_MDL_NAME_LBCS}" != "RAPX" ]; then
+
       thompson_mp_fix_files+=( "Thompson_MP_MONTHLY_CLIMO.nc" )
+
     fi  
 
     FIXgsm_FILES_TO_COPY_TO_FIXam+=( "${thompson_mp_fix_files[@]}" )


### PR DESCRIPTION
## DESCRIPTION OF CHANGES:
Add an if statement in set_thompson_mp_fix_files.sh to source Thompson climo file from $FIXgsm when using a combination of a Thompson-based SDF and non-RAP/HRRR external model data.  This will allow the user to correctly initialize the ice- and water-friendly aerosols when they are unavailable in the external model files.

## TESTS CONDUCTED: 
Tested end-to-end run on Jet.

## CONTRIBUTORS: 
@gsketefian

