### PR TITLE
Allow running from crontab on Cheyenne, as well as fix workflow generation on Cheyenne

### DIFF
--- a/ush/fill_jinja_template.py
+++ b/ush/fill_jinja_template.py
@@ -259,7 +259,7 @@ def main(cla):
     tvars = {}
     for var in template_vars:
 
-        if cfg.get(var) is None:
+        if cfg.get(var, "NULL") == "NULL":
             raise KeyError(f'{var} does not exist in user-supplied settings!')
 
         if not cla.quiet:

--- a/ush/launch_FV3LAM_wflow.sh
+++ b/ush/launch_FV3LAM_wflow.sh
@@ -91,13 +91,14 @@ expt_name="${EXPT_SUBDIR}"
 #
 #-----------------------------------------------------------------------
 #
-if [ "$MACHINE" != "CHEYENNE" ]; then
-  if [ "$MACHINE" = "ORION" ]; then
-    module load contrib rocoto
-  else
-    module purge
-    module load rocoto
-  fi
+if [ "$MACHINE" = "CHEYENNE" ]; then
+  module use -a /glade/p/ral/jntp/UFS_SRW_app/modules/
+  module load rocoto
+elif [ "$MACHINE" = "ORION" ]; then
+  module load contrib rocoto
+else
+  module purge
+  module load rocoto
 fi
 #
 #-----------------------------------------------------------------------

--- a/ush/templates/FV3LAM_wflow.xml
+++ b/ush/templates/FV3LAM_wflow.xml
@@ -64,17 +64,17 @@ the "HPSS" type is used for the GET_EXTRN_ICS_TN and GET_EXTRN_LBCS_TN
 tasks; and the "FCST" type is used for the RUN_FCST_TN task.
 -->
 
-{%- if (partition_default != "")  %}
+{%- if partition_default is not none %}
 <!ENTITY RSRV_DEFAULT "<account>&ACCOUNT;</account><queue>&QUEUE_DEFAULT;</queue><partition>{{ partition_default }}</partition>">
 {%- else %}
 <!ENTITY RSRV_DEFAULT "<account>&ACCOUNT;</account><queue>&QUEUE_DEFAULT;</queue>">
 {%- endif %}
-{%- if (partition_hpss != "")  %}
+{%- if partition_hpss is not none %}
 <!ENTITY RSRV_HPSS    "<account>&ACCOUNT;</account><queue>&QUEUE_HPSS;</queue><partition>{{ partition_hpss }}</partition>">
 {%- else %}
 <!ENTITY RSRV_HPSS    "<account>&ACCOUNT;</account><queue>&QUEUE_HPSS;</queue>">
 {%- endif %}
-{%- if (partition_fcst != "")  %}
+{%- if partition_fcst is not none %}
 <!ENTITY RSRV_FCST    "<account>&ACCOUNT;</account><queue>&QUEUE_FCST;</queue><partition>{{ partition_fcst }}</partition>">
 {%- else %}
 <!ENTITY RSRV_FCST    "<account>&ACCOUNT;</account><queue>&QUEUE_FCST;</queue>">


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Changes in #339 broke the jinja templating script for creating the workflow xml on platforms that do not have "partition_default", "partition_hpss", or "partition_fcst" settings. Basically it boils down to platforms whose job scheduler does not support the rocoto "partition" tag. Cheyenne is one of these platforms.

Additionally, this PR specifies the location of the new rocoto module on cheyenne, so tests can now be launched from a cron job on Cheyenne.

## TESTS CONDUCTED: 
Ran a small set of end-to-end tests on Cheyenne (intel) successfully with no failures: DOT_OR_USCORE, grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2, suite_FV3_GFS_v15p2, and suite_FV3_RRFS_v1beta (test location: /glade/scratch/kavulich/UFS_CAM/testing/rocoto_on_cheyenne/expt_dirs)

Ran a full suite of tests on Hera to ensure the jinja changes did not negatively impact tests on that platform. All tests expected to pass passed.

## ISSUE (optional): 
Resolves #326 