### PR TITLE
Remove all but supported CCPP suites from valid_param_vals.sh

### DIFF
--- a/ush/valid_param_vals.sh
+++ b/ush/valid_param_vals.sh
@@ -24,13 +24,7 @@ valid_vals_PREDEF_GRID_NAME=( \
 "GSD_RAP13km" \
 )
 valid_vals_CCPP_PHYS_SUITE=( \
-"FV3_CPT_v0" \
-"FV3_GFS_2017_gfdlmp" \
-"FV3_GFS_2017_gfdlmp_regional" \
-"FV3_GSD_SAR" \
-"FV3_GSD_v0" \
 "FV3_GFS_v15p2" \
-"FV3_GFS_v16beta" \
 "FV3_RRFS_v1beta" \
 ) 
 valid_vals_GFDLgrid_RES=("48" "96" "192" "384" "768" "1152" "3072")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES:  
Since only FV3_GFS_v15p2 and FV3_RRFS_v1beta CCPP suites are supported for the UFS release, this PR removes all other suites from valid_param_vals.sh on the release branch. 

This change should *only* be applied to the release branch; we will need a more elegant solution for the develop branch to keep up with CCPP suite changes going forward.

## TESTS CONDUCTED: 
When I attempted to run a test with an unsupported suite, the workflow generation script now fails as expected.

This change only impacts the workflow generation, but as a sanity check I also ran a build test on Hera, and ran the following end-to-end tests which completed successfully:
 - grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
 - grid_RRFS_CONUS_25km_ics_HRRRX_lbcs_RAPX_suite_RRFS_v1beta