### PR TITLE
Update weather model executable name

### DIFF
--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -545,7 +545,7 @@ cp_vrfy "${CCPP_PHYS_SUITE_IN_CCPP_FP}" "${CCPP_PHYS_SUITE_FP}"
 #
 #-----------------------------------------------------------------------
 #
-exec_fn="NEMS.exe"
+exec_fn="ufs_model"
 exec_fp="${SR_WX_APP_TOP_DIR}/bin/${exec_fn}"
 #Check for the old build location for fv3 executable
 if [ ! -f "${exec_fp}" ]; then


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The develop branch of ufs-weather-model was updated a couple months ago so that the weather model is no longer built as "NEMS.exe" (https://github.com/ufs-community/ufs-weather-model/pull/217). The workflow generation script needs to be updated with the new model executable name: ufs_model. 

This PR will need to be merged in order to use regional_workflow and the ufs-srweather-app with the most up-to-date develop branch of ufs-weather-model. A PR will be upcoming to update ufs-srweather-app to point to this hash once this PR is merged.

## TESTS CONDUCTED: 
Ran generation script successfully with fully updated workflow.

## ISSUE (optional): 
This is necessary (but not sufficient) in order to resolve https://github.com/ufs-community/ufs-srweather-app/issues/57
