### PR TITLE
Automate creation of symlinks to fixed files (i.e. pregenerated grid, orography, and surface climatology files) in NCO mode; treat fixed files in NCO mode more in line with that in community mode

### DIFF
--- a/jobs/JREGIONAL_MAKE_GRID
+++ b/jobs/JREGIONAL_MAKE_GRID
@@ -13,8 +13,8 @@
 # 1) grid_gen_scr:
 #
 #    This script generates grid files that will be used by subsequent
-#    preprocessing steps.  It places its output in the temporary direc-
-#    tory defined in GRID_DIR.  Note that:
+#    preprocessing steps.  It places its output in the directory defined 
+#    by GRID_DIR.  Note that:
 #
 #    a) This script creates grid files for each of the 7 tiles of the
 #       cubed sphere grid (where tiles 1 through 6 cover the globe, and
@@ -44,7 +44,7 @@
 # 2) orog_gen_scr:
 #
 #    This script generates the orography file.  It places its output in
-#    the temporary directory defined in OROG_DIR.  Note that:
+#    the directory defined by OROG_DIR.  Note that:
 #
 #    a) This script generates an orography file only on tile 7.
 #

--- a/scripts/exregional_make_orog.sh
+++ b/scripts/exregional_make_orog.sh
@@ -350,7 +350,6 @@ fn_suffix_with_halo="tile${TILE_RGNL}.halo${NHW}.nc"
 raw_orog_fn="${raw_orog_fn_prefix}.${fn_suffix_with_halo}"
 raw_orog_fp="${raw_dir}/${raw_orog_fn}"
 mv_vrfy "${raw_orog_fp_orig}" "${raw_orog_fp}"
-
 #
 #-----------------------------------------------------------------------
 #

--- a/tests/run_experiments.sh
+++ b/tests/run_experiments.sh
@@ -510,19 +510,7 @@ specified for this machine (MACHINE):
 # Directory for pregenerated grid files.
 #
   if [ ${RUN_TASK_MAKE_GRID} = "FALSE" ]; then
-
-    GRID_DIR="${pregen_basedir}/grid/${PREDEF_GRID_NAME}"
-    if [ "$MACHINE" = "HERA" ]; then
-      GRID_DIR="/scratch2/BMC/det/FV3LAM_pregen/grid/${PREDEF_GRID_NAME}"
-    elif [ "$MACHINE" = "CHEYENNE" ]; then
-      GRID_DIR="/glade/p/ral/jntp/UFS_CAM/FV3LAM_pregen/grid/${PREDEF_GRID_NAME}"
-    else
-      print_err_msg_exit "\
-The directory (GRID_DIR) in which the pregenerated grid files are located
-has not been specified for this machine (MACHINE):
-  MACHINE= \"${MACHINE}\""
-    fi
-
+    GRID_DIR="${pregen_basedir}/${PREDEF_GRID_NAME}/grid"
     str=${str}"
 #
 # Directory containing the pregenerated grid files.
@@ -534,18 +522,7 @@ GRID_DIR=\"${GRID_DIR}\""
 # Directory for pregenerated orography files.
 #
   if [ ${RUN_TASK_MAKE_OROG} = "FALSE" ]; then
-
-    if [ "$MACHINE" = "HERA" ]; then
-      OROG_DIR="/scratch2/BMC/det/FV3LAM_pregen/orog/${PREDEF_GRID_NAME}"
-    elif [ "$MACHINE" = "CHEYENNE" ]; then
-      OROG_DIR="/glade/p/ral/jntp/UFS_CAM/FV3LAM_pregen/orog/${PREDEF_GRID_NAME}"
-    else
-      print_err_msg_exit "\
-The directory (OROG_DIR) in which the pregenerated grid files are located
-has not been specified for this machine (MACHINE):
-  MACHINE= \"${MACHINE}\""
-    fi
-
+    OROG_DIR="${pregen_basedir}/${PREDEF_GRID_NAME}/orog"
     str=${str}"
 #
 # Directory containing the pregenerated orography files.
@@ -557,18 +534,7 @@ OROG_DIR=\"${OROG_DIR}\""
 # Directory for pregenerated surface climatology files.
 #
   if [ ${RUN_TASK_MAKE_SFC_CLIMO} = "FALSE" ]; then
-
-    if [ "$MACHINE" = "HERA" ]; then
-      SFC_CLIMO_DIR="/scratch2/BMC/det/FV3LAM_pregen/sfc_climo/${PREDEF_GRID_NAME}"
-    elif [ "$MACHINE" = "CHEYENNE" ]; then
-      SFC_CLIMO_DIR="/glade/p/ral/jntp/UFS_CAM/FV3LAM_pregen/sfc_climo/${PREDEF_GRID_NAME}"
-    else
-      print_err_msg_exit "\
-The directory (SFC_CLIMO_DIR) in which the pregenerated grid files are
-located has not been specified for this machine (MACHINE):
-  MACHINE= \"${MACHINE}\""
-    fi
-
+    SFC_CLIMO_DIR="${pregen_basedir}/${PREDEF_GRID_NAME}/sfc_climo"
     str=${str}"
 #
 # Directory containing the pregenerated surface climatology files.
@@ -628,21 +594,7 @@ SFC_CLIMO_DIR=\"${SFC_CLIMO_DIR}\""
 #   \$PTMP/com/\$NET/\$RUN/\$RUN.\$yyyymmdd/\$hh
 #
 RUN=\"\${EXPT_SUBDIR}\"
-envir=\"\${EXPT_SUBDIR}\"
-#
-# In NCO mode, the user must manually (e.g. after doing the build step)
-# create the symlink \"\${FIXrrfs}/fix_sar\" that points to EMC's FIXsar
-# directory on the machine.  For example, on hera, the symlink's target
-# needs to be
-#
-#   /scratch2/NCEPDEV/fv3-cam/emc.campara/fix_fv3cam/fix_sar
-#
-# The experiment generation script will then set FIXsar to
-#
-#   FIXsar=\"\${FIXrrfs}/fix_sar/\${PREDEF_GRID_NAME}\"
-#
-# where PREDEF_GRID_NAME has the value set above.
-#"
+envir=\"\${EXPT_SUBDIR}\""
 #
 # Set COMINgfs.
 #
@@ -653,10 +605,13 @@ envir=\"\${EXPT_SUBDIR}\"
 
       if [ "$MACHINE" = "HERA" ]; then
         COMINgfs="/scratch1/NCEPDEV/hwrf/noscrub/hafs-input/COMGFS"
+        FIXLAM_NCO_BASEDIR="/scratch2/BMC/det/FV3LAM_pregen"
       elif [ "$MACHINE" = "JET" ]; then
         COMINgfs="/lfs1/HFIP/hwrf-data/hafs-input/COMGFS"
+        FIXLAM_NCO_BASEDIR="/needs/to/be/specified"
       elif [ "$MACHINE" = "CHEYENNE" ]; then
         COMINgfs="/glade/scratch/ketefian/NCO_dirs/COMGFS"
+        FIXLAM_NCO_BASEDIR="/needs/to/be/specified"
       else
         print_err_msg_exit "\
 The directory (COMINgfs) that needs to be specified when running the
@@ -672,7 +627,13 @@ for this machine (MACHINE):
 # mode (RUN_ENVIR set to \"nco\") AND using the FV3GFS or the GSMGFS as
 # the external model for ICs and/or LBCs.
 #
-COMINgfs=\"${COMINgfs}\""
+COMINgfs=\"${COMINgfs}\"
+#
+# Directory in which the pregenerated grid, orography, and surface 
+# climatology \"fixed\" files are located.  In NCO mode, a symlink will
+# be created under FIXrrfs that points to this directory.
+#
+FIXLAM_NCO_BASEDIR=\"${FIXLAM_NCO_BASEDIR}\""
 
     fi
 #

--- a/tests/run_experiments.sh
+++ b/tests/run_experiments.sh
@@ -629,9 +629,11 @@ for this machine (MACHINE):
 #
 COMINgfs=\"${COMINgfs}\"
 #
-# Directory in which the pregenerated grid, orography, and surface 
-# climatology \"fixed\" files are located.  In NCO mode, a symlink will
-# be created under FIXrrfs that points to this directory.
+# The base directory in which the pregenerated grid, orography, and surface 
+# climatology \"fixed\" files used in NCO mode are located.  In NCO mode,
+# the workflow scripts will create a symlink (at the location specified 
+# by FIXLAM) to a subdirectory under FIXLAM_NCO_BASDEDIR.  (The name of 
+# the subdirectory is the name of the grid specified by PREDEF_GRID_NAME.)
 #
 FIXLAM_NCO_BASEDIR=\"${FIXLAM_NCO_BASEDIR}\""
 

--- a/tests/run_experiments.sh
+++ b/tests/run_experiments.sh
@@ -493,6 +493,13 @@ VERBOSE=\"${VERBOSE}\""
      [ ${RUN_TASK_MAKE_OROG} = "FALSE" ] || \
      [ ${RUN_TASK_MAKE_SFC_CLIMO} = "FALSE" ]; then
 
+# Note:
+# Now that the "grid", "orog", and "sfc_climo" sub-subdirectories under
+# pregen_basedir have been removed, we don't need the variable pregen_basedir
+# and can instead have the variable "pregen_dir" that gets set to 
+# ${pregen_basedir}/${PREDEF_GRID_NAME}, and pregen_dir can then be used
+# to set GRID_DIR, OROG_DIR, and/or SFC_CLIMO_DIR below.
+
     if [ "$MACHINE" = "HERA" ]; then
       pregen_basedir="/scratch2/BMC/det/FV3LAM_pregen"
     elif [ "$MACHINE" = "CHEYENNE" ]; then
@@ -510,7 +517,7 @@ specified for this machine (MACHINE):
 # Directory for pregenerated grid files.
 #
   if [ ${RUN_TASK_MAKE_GRID} = "FALSE" ]; then
-    GRID_DIR="${pregen_basedir}/${PREDEF_GRID_NAME}/grid"
+    GRID_DIR="${pregen_basedir}/${PREDEF_GRID_NAME}"
     str=${str}"
 #
 # Directory containing the pregenerated grid files.
@@ -522,7 +529,7 @@ GRID_DIR=\"${GRID_DIR}\""
 # Directory for pregenerated orography files.
 #
   if [ ${RUN_TASK_MAKE_OROG} = "FALSE" ]; then
-    OROG_DIR="${pregen_basedir}/${PREDEF_GRID_NAME}/orog"
+    OROG_DIR="${pregen_basedir}/${PREDEF_GRID_NAME}"
     str=${str}"
 #
 # Directory containing the pregenerated orography files.
@@ -534,7 +541,7 @@ OROG_DIR=\"${OROG_DIR}\""
 # Directory for pregenerated surface climatology files.
 #
   if [ ${RUN_TASK_MAKE_SFC_CLIMO} = "FALSE" ]; then
-    SFC_CLIMO_DIR="${pregen_basedir}/${PREDEF_GRID_NAME}/sfc_climo"
+    SFC_CLIMO_DIR="${pregen_basedir}/${PREDEF_GRID_NAME}"
     str=${str}"
 #
 # Directory containing the pregenerated surface climatology files.

--- a/ush/config.nco.sh
+++ b/ush/config.nco.sh
@@ -22,24 +22,12 @@ CYCL_HRS=( "18" )
 EXTRN_MDL_NAME_ICS="FV3GFS"
 EXTRN_MDL_NAME_LBCS="FV3GFS"
 
+#
 # The following must be modified for different platforms and users.
+#
 RUN="an_experiment"
 COMINgfs="/scratch1/NCEPDEV/hwrf/noscrub/hafs-input/COMGFS"     # Path to directory containing files from the external model (FV3GFS).
+FIXLAM_NCO_BASEDIR="/scratch2/BMC/det/FV3LAM_pregen"            # Path to directory containing the pregenerated grid, orography, and surface climatology "fixed" files to use for the experiment.
 STMP="/scratch2/BMC/det/Gerard.Ketefian/UFS_CAM/NCO_dirs/stmp"  # Path to directory STMP that mostly contains input files.
 PTMP="/scratch2/BMC/det/Gerard.Ketefian/UFS_CAM/NCO_dirs/ptmp"  # Path to directory PTMP in which the experiment's output files will be placed.
-
-#
-# In NCO mode, the user must manually (e.g. after doing the build step)
-# create the symlink "${FIXrrfs}/fix_sar" that points to EMC's FIXLAM
-# directory on the machine.  For example, on hera, the symlink's target
-# needs to be
-#
-#   /scratch2/NCEPDEV/fv3-cam/emc.campara/fix_fv3cam/fix_sar
-#
-# The experiment generation script will then set FIXLAM to 
-#
-#   FIXLAM="${FIXrrfs}/fix_lam/${PREDEF_GRID_NAME}"
-#
-# where PREDEF_GRID_NAME has the value set above.
-#
 

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -175,6 +175,18 @@ EXPT_SUBDIR=""
 #
 #   $COMINgfs/gfs.$yyyymmdd/$hh
 #
+# FIXLAM_NCO_BASEDIR:
+# The base directory containing pregenerated grid, orography, and surface 
+# climatology files.  For the pregenerated grid specified by PREDEF_GRID_NAME, 
+# these "fixed" files are located in:
+#
+#   ${FIXLAM_NCO_BASEDIR}/${PREDEF_GRID_NAME}
+#
+# The workflow scripts will create a symlink under FIXrrfs that will point 
+# to this directory.  This variable should be set to a null string in 
+# this file, but it can be specified in the user-specified workflow 
+# configuration file (EXPT_CONFIG_FN)
+#
 # STMP:
 # The beginning portion of the directory that will contain cycle-dependent
 # model input files, symlinks to cycle-independent input files, and raw 
@@ -214,6 +226,7 @@ EXPT_SUBDIR=""
 #-----------------------------------------------------------------------
 #
 COMINgfs="/base/path/of/directory/containing/gfs/input/files"
+FIXLAM_NCO_BASEDIR=""
 STMP="/base/path/of/directory/containing/model/input/and/raw/output/files"
 NET="rrfs"
 envir="para"

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -182,10 +182,11 @@ EXPT_SUBDIR=""
 #
 #   ${FIXLAM_NCO_BASEDIR}/${PREDEF_GRID_NAME}
 #
-# The workflow scripts will create a symlink under FIXrrfs that will point 
-# to this directory.  This variable should be set to a null string in 
-# this file, but it can be specified in the user-specified workflow 
-# configuration file (EXPT_CONFIG_FN)
+# The workflow scripts will create a symlink in the experiment directory
+# that will point to a subdirectory (having the name of the grid being
+# used) under this directory.  This variable should be set to a null 
+# string in this file, but it can be specified in the user-specified 
+# workflow configuration file (EXPT_CONFIG_FN)
 #
 # STMP:
 # The beginning portion of the directory that will contain cycle-dependent

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -407,15 +407,11 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-# Copy fixed files from system directory to the FIXam directory (which
-# is under the experiment directory).  Note that some of these files get
-# renamed during the copy process.
+# If running in non-NCO mode, copy fixed files from system directory to
+# the FIXam directory (which is under the experiment directory).
 #
 #-----------------------------------------------------------------------
 #
-
-# In NCO mode, we assume the following copy operation is done beforehand,
-# but that can be changed.
 if [ "${RUN_ENVIR}" != "nco" ]; then
 
   print_info_msg "$VERBOSE" "

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -407,12 +407,39 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-# If running in non-NCO mode, copy fixed files from system directory to
-# the FIXam directory (which is under the experiment directory).
+# Create the FIXam directory under the experiment directory.  In NCO mode,
+# this will be a symlink to the directory specified in FIXgsm, while in
+# community mode, it will be an actual directory with files copied into
+# it from FIXgsm.
 #
 #-----------------------------------------------------------------------
 #
-if [ "${RUN_ENVIR}" != "nco" ]; then
+# First, consider NCO mode.
+#
+if [ "${RUN_ENVIR}" = "nco" ]; then
+
+  ln_vrfy -fsn "$FIXgsm" "$FIXam"
+#
+# Resolve the target directory that the FIXam symlink points to and check 
+# that it exists.
+#
+  path_resolved=$( readlink -m "$FIXam" )
+  if [ ! -d "${path_resolved}" ]; then
+    print_err_msg_exit "\
+In order to be able to generate a forecast experiment in NCO mode (i.e.
+when RUN_ENVIR set to \"nco\"), the path specified by FIXam after resolving
+all symlinks (path_resolved) must be an existing directory (but in this
+case isn't):
+  RUN_ENVIR = \"${RUN_ENVIR}\"
+  FIXam = \"$FIXam\"
+  path_resolved = \"${path_resolved}\"
+Please ensure that path_resolved is an existing directory and then rerun
+the experiment generation script."
+  fi
+#
+# Now consider community mode.
+#
+else
 
   print_info_msg "$VERBOSE" "
 Copying fixed files from system directory (FIXgsm) to a subdirectory

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -669,48 +669,56 @@ case $MACHINE in
     FIXgsm=${FIXgsm:-"/gpfs/hps3/emc/global/noscrub/emc.glopara/git/fv3gfs/fix/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/gpfs/hps3/emc/global/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/gpfs/hps3/emc/global/noscrub/emc.glopara/git/fv3gfs/fix/fix_sfc_climo"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/needs/to/be/specified"}
     ;;
 
   "WCOSS_DELL_P3")
     FIXgsm=${FIXgsm:-"/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_sfc_climo"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/needs/to/be/specified"}
     ;;
 
   "HERA")
     FIXgsm=${FIXgsm:-"/scratch1/NCEPDEV/global/glopara/fix/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/scratch1/NCEPDEV/global/glopara/fix/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/scratch1/NCEPDEV/global/glopara/fix/fix_sfc_climo"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/scratch2/BMC/det/Gerard.Ketefian/UFS_CAM/FV3LAM_pregen"}
     ;;
 
   "ORION")
     FIXgsm=${FIXgsm:-"/work/noaa/global/glopara/fix/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/work/noaa/global/glopara/fix/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/work/noaa/global/glopara/fix/fix_sfc_climo"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/needs/to/be/specified"}
     ;;
 
   "JET")
     FIXgsm=${FIXgsm:-"/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix/fix_sfc_climo"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/needs/to/be/specified"}
     ;;
 
   "ODIN")
     FIXgsm=${FIXgsm:-"/scratch/ywang/fix/theia_fix/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/scratch/ywang/fix/theia_fix/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/scratch/ywang/fix/climo_fields_netcdf"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/needs/to/be/specified"}
     ;;
 
   "CHEYENNE")
     FIXgsm=${FIXgsm:-"/glade/p/ral/jntp/UFS_CAM/fix/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/glade/p/ral/jntp/UFS_CAM/fix/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/glade/p/ral/jntp/UFS_CAM/fix/climo_fields_netcdf"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/needs/to/be/specified"}
     ;;
 
   "STAMPEDE")
     FIXgsm=${FIXgsm:-"/work/00315/tg455890/stampede2/regional_fv3/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/work/00315/tg455890/stampede2/regional_fv3/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/work/00315/tg455890/stampede2/regional_fv3/climo_fields_netcdf"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/needs/to/be/specified"}
     ;;
 
   *)
@@ -720,6 +728,7 @@ One or more fix file directories have not been specified for this machine:
   FIXgsm = \"${FIXgsm:-\"\"}
   TOPO_DIR = \"${TOPO_DIR:-\"\"}
   SFC_CLIMO_INPUT_DIR = \"${SFC_CLIMO_INPUT_DIR:-\"\"}
+  FIXLAM_NCO_BASEDIR = \"${FIXLAM_NCO_BASEDIR:-\"\"}
 You can specify the missing location(s) in config.sh"
     ;;
 
@@ -1014,57 +1023,10 @@ LOGDIR="${EXPTDIR}/log"
 if [ "${RUN_ENVIR}" = "nco" ]; then
 
   FIXam="${FIXrrfs}/fix_am"
-#
-# In NCO mode (i.e. if RUN_ENVIR set to "nco"), it is assumed that before
-# running the experiment generation script, the path specified in FIXam 
-# already exists and is either itself the directory in which various fixed
-# files (but not the ones containing the regional grid and the orography
-# and surface climatology on that grid) are located, or it is a symlink 
-# to such a directory.  Resolve any symlinks in the path specified by 
-# FIXam and check that this is the case.
-#
-  path_resolved=$( readlink -m "$FIXam" )
-  if [ ! -d "${path_resolved}" ]; then
-    print_err_msg_exit "\
-In order to be able to generate a forecast experiment in NCO mode (i.e. 
-when RUN_ENVIR set to \"nco\"), the path specified by FIXam after resolving 
-all symlinks (path_resolved) must be an existing directory (but in this
-case isn't):
-  RUN_ENVIR = \"${RUN_ENVIR}\"
-  FIXam = \"$FIXam\"
-  path_resolved = \"${path_resolved}\"
-Please ensure that path_resolved is an existing directory and then rerun 
-the experiment generation script."
-  fi
-
-  FIXLAM="${FIXrrfs}/fix_lam/${PREDEF_GRID_NAME}"
-#
-# In NCO mode (i.e. if RUN_ENVIR set to "nco"), it is assumed that before
-# running the experiment generation script, the path specified in FIXLAM 
-# already exists and is either itself the directory in which the fixed 
-# grid, orography, and surface climatology files are located, or it is a
-# symlink to such a directory.  Resolve any symlinks in the path specified
-# by FIXLAM and check that this is the case.
-#
-  path_resolved=$( readlink -m "$FIXLAM" )
-  if [ ! -d "${path_resolved}" ]; then
-    print_err_msg_exit "\
-In order to be able to generate a forecast experiment in NCO mode (i.e. 
-when RUN_ENVIR set to \"nco\"), the path specified by FIXLAM after resolving 
-all symlinks (path_resolved) must be an existing directory (but in this
-case isn't):
-  RUN_ENVIR = \"${RUN_ENVIR}\"
-  FIXLAM = \"$FIXLAM\"
-  path_resolved = \"${path_resolved}\"
-Please ensure that path_resolved is an existing directory and then rerun 
-the experiment generation script."
-  fi
-
+  FIXLAM="${FIXrrfs}/fix_lam"
   CYCLE_BASEDIR="$STMP/tmpnwprd/$RUN"
   check_for_preexist_dir_file "${CYCLE_BASEDIR}" "${PREEXISTING_DIR_METHOD}"
-
   COMROOT="$PTMP/com"
-
   COMOUT_BASEDIR="$COMROOT/$NET/$envir"
   check_for_preexist_dir_file "${COMOUT_BASEDIR}" "${PREEXISTING_DIR_METHOD}"
 
@@ -1685,6 +1647,73 @@ elif [ "${GRID_GEN_METHOD}" = "ESGgrid" ]; then
     output_varname_neg_ny_of_dom_with_wide_halo="NEG_NY_OF_DOM_WITH_WIDE_HALO"
 
 fi
+
+
+
+#
+#-----------------------------------------------------------------------
+#
+# If running in NCO mode, create necessary symlinks under FIXrrfs to the
+# fixed-file directories.
+#
+#-----------------------------------------------------------------------
+#
+if [ "${RUN_ENVIR}" = "nco" ]; then
+
+  mkdir_vrfy -p "$FIXrrfs"
+
+  ln_vrfy -fsn "$FIXgsm" "$FIXam" 
+#
+# In NCO mode (i.e. if RUN_ENVIR set to "nco"), it is assumed that before
+# running the experiment generation script, the path specified in FIXam 
+# already exists and is either itself the directory in which various fixed
+# files (but not the ones containing the regional grid and the orography
+# and surface climatology on that grid) are located, or it is a symlink 
+# to such a directory.  Resolve any symlinks in the path specified by 
+# FIXam and check that this is the case.
+#
+  path_resolved=$( readlink -m "$FIXam" )
+  if [ ! -d "${path_resolved}" ]; then
+    print_err_msg_exit "\
+In order to be able to generate a forecast experiment in NCO mode (i.e. 
+when RUN_ENVIR set to \"nco\"), the path specified by FIXam after resolving 
+all symlinks (path_resolved) must be an existing directory (but in this
+case isn't):
+  RUN_ENVIR = \"${RUN_ENVIR}\"
+  FIXam = \"$FIXam\"
+  path_resolved = \"${path_resolved}\"
+Please ensure that path_resolved is an existing directory and then rerun 
+the experiment generation script."
+  fi
+
+  ln_vrfy -fsn "${FIXLAM_NCO_BASEDIR}/${PREDEF_GRID_NAME}" "$FIXLAM" 
+#
+# In NCO mode (i.e. if RUN_ENVIR set to "nco"), it is assumed that before
+# running the experiment generation script, the path specified in FIXLAM 
+# already exists and is either itself the directory in which the fixed 
+# grid, orography, and surface climatology files are located, or it is a
+# symlink to such a directory.  Resolve any symlinks in the path specified
+# by FIXLAM and check that this is the case.
+#
+  path_resolved=$( readlink -m "$FIXLAM" )
+  if [ ! -d "${path_resolved}" ]; then
+    print_err_msg_exit "\
+In order to be able to generate a forecast experiment in NCO mode (i.e. 
+when RUN_ENVIR set to \"nco\"), the path specified by FIXLAM after resolving 
+all symlinks (path_resolved) must be an existing directory (but in this
+case isn't):
+  RUN_ENVIR = \"${RUN_ENVIR}\"
+  FIXLAM = \"$FIXLAM\"
+  path_resolved = \"${path_resolved}\"
+Please ensure that path_resolved is an existing directory and then rerun 
+the experiment generation script."
+  fi
+
+fi
+
+
+
+
 #
 #-----------------------------------------------------------------------
 #
@@ -1708,7 +1737,7 @@ if [ "${RUN_ENVIR}" = "nco" ]; then
 
   suffix="${DOT_OR_USCORE}mosaic.halo${NH3}.nc"
   glob_pattern="C*$suffix"
-  cd_vrfy $FIXLAM
+  cd_vrfy "$FIXLAM"
   num_files=$( ls -1 ${glob_pattern} 2>/dev/null | wc -l )
 
   if [ "${num_files}" -ne "1" ]; then

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -660,7 +660,6 @@ SRC_DIR="${SR_WX_APP_TOP_DIR}/src"
 PARMDIR="$HOMErrfs/parm"
 MODULES_DIR="$HOMErrfs/modulefiles"
 EXECDIR="${SR_WX_APP_TOP_DIR}/bin"
-FIXrrfs="$HOMErrfs/fix"
 TEMPLATE_DIR="$USHDIR/templates"
 
 case $MACHINE in
@@ -1020,10 +1019,11 @@ check_for_preexist_dir_file "$EXPTDIR" "${PREEXISTING_DIR_METHOD}"
 #
 LOGDIR="${EXPTDIR}/log"
 
+FIXam="${EXPTDIR}/fix_am"
+FIXLAM="${EXPTDIR}/fix_lam"
+
 if [ "${RUN_ENVIR}" = "nco" ]; then
 
-  FIXam="${FIXrrfs}/fix_am"
-  FIXLAM="${FIXrrfs}/fix_lam"
   CYCLE_BASEDIR="$STMP/tmpnwprd/$RUN"
   check_for_preexist_dir_file "${CYCLE_BASEDIR}" "${PREEXISTING_DIR_METHOD}"
   COMROOT="$PTMP/com"
@@ -1032,8 +1032,6 @@ if [ "${RUN_ENVIR}" = "nco" ]; then
 
 else
 
-  FIXam="${EXPTDIR}/fix_am"
-  FIXLAM="${EXPTDIR}/fix_lam"
   CYCLE_BASEDIR="$EXPTDIR"
   COMROOT=""
   COMOUT_BASEDIR=""
@@ -1647,20 +1645,26 @@ elif [ "${GRID_GEN_METHOD}" = "ESGgrid" ]; then
     output_varname_neg_ny_of_dom_with_wide_halo="NEG_NY_OF_DOM_WITH_WIDE_HALO"
 
 fi
-
+#
+#-----------------------------------------------------------------------
+#
+# Create a new experiment directory.  Note that at this point we are 
+# guaranteed that there is no preexisting experiment directory.
+#
+#-----------------------------------------------------------------------
+#
+mkdir_vrfy -p "$EXPTDIR"
 
 
 #
 #-----------------------------------------------------------------------
 #
-# If running in NCO mode, create necessary symlinks under FIXrrfs to the
+# If running in NCO mode, create necessary symlinks that point to the
 # fixed-file directories.
 #
 #-----------------------------------------------------------------------
 #
 if [ "${RUN_ENVIR}" = "nco" ]; then
-
-  mkdir_vrfy -p "$FIXrrfs"
 
   ln_vrfy -fsn "$FIXgsm" "$FIXam" 
 #
@@ -1712,24 +1716,19 @@ the experiment generation script."
 fi
 
 
-
-
 #
 #-----------------------------------------------------------------------
 #
-#
+# Set RES_IN_FIXLAM_FILENAMES.  The way this is set depends on whether
+# the workflow is running in NCO mode or community mode.
 #
 #-----------------------------------------------------------------------
 #
 RES_IN_FIXLAM_FILENAMES=""
-
-if [ "${RUN_ENVIR}" != "nco" ]; then
-  mkdir_vrfy -p "$FIXLAM"
-fi
 #
 #-----------------------------------------------------------------------
 #
-#
+# First, consider NCO mode.
 #
 #-----------------------------------------------------------------------
 #
@@ -1760,8 +1759,16 @@ does not match the resolution specified by GFDLgrid_RES:
   GFDLgrid_RES = ${GFDLgrid_RES}
   RES_IN_FIXLAM_FILENAMES = ${RES_IN_FIXLAM_FILENAMES}"
   fi
-
+#
+#-----------------------------------------------------------------------
+#
+# Now consider community mode.
+#
+#-----------------------------------------------------------------------
+#
 else
+
+  mkdir_vrfy -p "$FIXLAM"
 #
 #-----------------------------------------------------------------------
 #
@@ -1966,17 +1973,6 @@ fi
 #-----------------------------------------------------------------------
 #
 NNODES_RUN_FCST=$(( (PE_MEMBER01 + PPN_RUN_FCST - 1)/PPN_RUN_FCST ))
-#
-#-----------------------------------------------------------------------
-#
-# Create a new experiment directory.  Note that at this point we are 
-# guaranteed that there is no preexisting experiment directory.
-#
-#-----------------------------------------------------------------------
-#
-mkdir_vrfy -p "$EXPTDIR"
-
-
 
 
 
@@ -2319,7 +2315,6 @@ SRC_DIR="$SRC_DIR"
 PARMDIR="$PARMDIR"
 MODULES_DIR="${MODULES_DIR}"
 EXECDIR="$EXECDIR"
-FIXrrfs="$FIXrrfs"
 FIXam="$FIXam"
 FIXLAM="$FIXLAM"
 FIXgsm="$FIXgsm"

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -682,7 +682,7 @@ case $MACHINE in
     FIXgsm=${FIXgsm:-"/scratch1/NCEPDEV/global/glopara/fix/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/scratch1/NCEPDEV/global/glopara/fix/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/scratch1/NCEPDEV/global/glopara/fix/fix_sfc_climo"}
-    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/scratch2/BMC/det/Gerard.Ketefian/UFS_CAM/FV3LAM_pregen"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/scratch2/BMC/det/FV3LAM_pregen"}
     ;;
 
   "ORION")
@@ -1341,7 +1341,7 @@ of FIXLAM.  Reset values are:"
 "
 
     print_info_msg "$msg"
-  
+
   fi
 
   if [ "${RUN_TASK_MAKE_OROG}" = "TRUE" ] || \
@@ -1369,7 +1369,7 @@ of FIXLAM.  Reset values are:"
 "
 
     print_info_msg "$msg"
-  
+
   fi
 
   if [ "${RUN_TASK_MAKE_SFC_CLIMO}" = "TRUE" ] || \
@@ -1397,7 +1397,7 @@ contents of FIXLAM.  Reset values are:"
 "
 
     print_info_msg "$msg"
-  
+
   fi
 
 else
@@ -1452,14 +1452,12 @@ files does not exist:
 #-----------------------------------------------------------------------
 #
   if [ "${RUN_TASK_MAKE_SFC_CLIMO}" = "FALSE" ]; then
-
     if [ ! -d "${SFC_CLIMO_DIR}" ]; then
       print_err_msg_exit "\
 The directory (SFC_CLIMO_DIR) that should contain the pre-generated orography
 files does not exist:
   SFC_CLIMO_DIR = \"${SFC_CLIMO_DIR}\""
     fi
-
   else
     SFC_CLIMO_DIR="$EXPTDIR/sfc_climo"
   fi
@@ -1786,7 +1784,7 @@ else
       file_group="grid" \
       output_varname_res_in_filenames="res_in_grid_fns" || \
     print_err_msg_exit "\
-  Call to function to create links to grid files failed."
+Call to function to create links to grid files failed."
 
     RES_IN_FIXLAM_FILENAMES="${res_in_grid_fns}"
 
@@ -1808,16 +1806,16 @@ else
       file_group="orog" \
       output_varname_res_in_filenames="res_in_orog_fns" || \
     print_err_msg_exit "\
-  Call to function to create links to orography files failed."
+Call to function to create links to orography files failed."
 
     if [ ! -z "${RES_IN_FIXLAM_FILENAMES}" ] && \
        [ "${res_in_orog_fns}" -ne "${RES_IN_FIXLAM_FILENAMES}" ]; then
       print_err_msg_exit "\
-  The resolution extracted from the orography file names (res_in_orog_fns)
-  does not match the resolution in other groups of files already consi-
-  dered (RES_IN_FIXLAM_FILENAMES):
-    res_in_orog_fns = ${res_in_orog_fns}
-    RES_IN_FIXLAM_FILENAMES = ${RES_IN_FIXLAM_FILENAMES}"
+The resolution extracted from the orography file names (res_in_orog_fns)
+does not match the resolution in other groups of files already consi-
+dered (RES_IN_FIXLAM_FILENAMES):
+  res_in_orog_fns = ${res_in_orog_fns}
+  RES_IN_FIXLAM_FILENAMES = ${RES_IN_FIXLAM_FILENAMES}"
     else
       RES_IN_FIXLAM_FILENAMES="${res_in_orog_fns}"
     fi
@@ -1841,16 +1839,16 @@ else
       file_group="sfc_climo" \
       output_varname_res_in_filenames="res_in_sfc_climo_fns" || \
     print_err_msg_exit "\
-  Call to function to create links to surface climatology files failed."
+Call to function to create links to surface climatology files failed."
 
     if [ ! -z "${RES_IN_FIXLAM_FILENAMES}" ] && \
        [ "${res_in_sfc_climo_fns}" -ne "${RES_IN_FIXLAM_FILENAMES}" ]; then
       print_err_msg_exit "\
-  The resolution extracted from the surface climatology file names (res_-
-  in_sfc_climo_fns) does not match the resolution in other groups of files
-  already considered (RES_IN_FIXLAM_FILENAMES):
-    res_in_sfc_climo_fns = ${res_in_sfc_climo_fns}
-    RES_IN_FIXLAM_FILENAMES = ${RES_IN_FIXLAM_FILENAMES}"
+The resolution extracted from the surface climatology file names (res_-
+in_sfc_climo_fns) does not match the resolution in other groups of files
+already considered (RES_IN_FIXLAM_FILENAMES):
+  res_in_sfc_climo_fns = ${res_in_sfc_climo_fns}
+  RES_IN_FIXLAM_FILENAMES = ${RES_IN_FIXLAM_FILENAMES}"
     else
       RES_IN_FIXLAM_FILENAMES="${res_in_sfc_climo_fns}"
     fi


### PR DESCRIPTION
## DESCRIPTION OF CHANGES:

### Main changes:
* In NCO mode, remove requirement that there be "fix_am" and "fix_lam" symlinks under a directory named "fix" under "regional_workflow".  Instead, move "fix_am" and "fix_lam" to under the experiment directory, and have "fix_am" be a symlink like before but (for consistency with what is done in community mode) have "fix_lam" be an actual directory (not a symlink) that contains symlinks to files in some other specified directory.  
  * For clarity, move creation of the "fix_am" symlink in NCO mode from setup.sh to generate_FV3LAM_wflow.sh, and make it part of the same if-statement in generate_FV3LAM_wflow.sh that creates the "fix_am" directory in community mode.
  * Assume that in NCO mode, the pregenerated grid, orography, and surface climatology files are located in the directory ${FIXLAM_NCO_BASEDIR}/${PREDEF_GRID_NAME}, where FIXLAM_NCO_BASEDIR is a new workflow variable that specifies the base directory in which these files are located.  Thus, the files must be located in a subdirectory having the name of the predefined grid under ${FIXLAM_NCO_BASEDIR}.  Note that FIXLAM_NCO_BASEDIR is only used in NCO mode.
  * With the above changes, the creation of symlinks in the "fix_lam" subdirectory under the experiment directory and the setting of the variable RES_IN_FIXLAM_FILENAMES can now be handled in the same way in NCO mode as in community mode.  Thus, remove section of code in setup.sh that sets RES_IN_FIXLAM_FILENAMES specifically in NCO mode, and use the section of code that was previously only for community mode to create the symlinks and set RES_IN_FIXLAM_FILENAMES in both NCO and community modes.
* Remove check near the top of setup.sh on existence of SFC_CLIMO_DIR when RUN_TASK_MAKE_SFC_CLIMO is set to "FALSE" because this test is in effect now performed later in the script, both for NCO mode and community mode.
* For simplicity, remove setting of SFC_CLIMO_DIR to a null string when it is not already a null string and RUN_TASK_MAKE_SFC_CLIMO is set to "TRUE" because this is not done for GRID_DIR and OROG_DIR.
* For the purposes of running the WE2E tests, assume that when using pregenerated grid, orography, and surface climatology files in community mode, the files are located directly under the ${PREDEF_GRID_NAME} subdirectory of some specified base directory just as we assume is the case in NCO mode.  Thus, in run_experiments.sh, remove the "grid", "orog", and "sfc_climo" subdirectories in the settings of GRID_DIR, OROG_DIR, and SFC_CLIMO_DIR.  Note that this is only for the WE2E testing system.  Users can still specify (in config.sh) independent directories for GRID_DIR, OROG_DIR, and SFC_CLIMO_DIR when using pregenerated files in community mode.
* In the sample NCO mode workflow configuration file config.nco.sh, added the variable FIXLAM_NCO_BASEDIR (for a valid value on Hera only; values are platform and user dependent).

### Improvements:
* Add missing code that checks that RUN_TASK_MAKE_OROG is set to a valid value (just like there is code to check that RUN_TASK_MAKE_GRID and RUN_TASK_MAKE_SFC_CLIMO are set to valid values).
* Edit error messages in setup.sh to make them more accurate and clearer.
* Clean up comments.

## TESTS CONDUCTED: 
Ran the following WE2E tests on Hera:
* nco_CONUS_25km_GFDLgrid
* nco_RRFS_CONUS_25km_HRRR_RAP
* pregen_grid_orog_sfc_climo
* regional_002

These are ones that test the workflow in NCO mode (nco_CONUS_25km_GFDLgrid, nco_RRFS_CONUS_25km_HRRR_RAP), in community mode with pregenerated files (pregen_grid_orog_sfc_climo), and in community mode without pregenerated files (regional_002).  All tests were successful.

