### PR TITLE
Automate creation of symlinks to fixed files (i.e. pregenerated grid, orography, and surface climatology files) in NCO mode; treat fixed files in NCO mode more in line with that in community mode

### DIFF
--- a/jobs/JREGIONAL_MAKE_GRID
+++ b/jobs/JREGIONAL_MAKE_GRID
@@ -13,8 +13,8 @@
 # 1) grid_gen_scr:
 #
 #    This script generates grid files that will be used by subsequent
-#    preprocessing steps.  It places its output in the temporary direc-
-#    tory defined in GRID_DIR.  Note that:
+#    preprocessing steps.  It places its output in the directory defined 
+#    by GRID_DIR.  Note that:
 #
 #    a) This script creates grid files for each of the 7 tiles of the
 #       cubed sphere grid (where tiles 1 through 6 cover the globe, and
@@ -44,7 +44,7 @@
 # 2) orog_gen_scr:
 #
 #    This script generates the orography file.  It places its output in
-#    the temporary directory defined in OROG_DIR.  Note that:
+#    the directory defined by OROG_DIR.  Note that:
 #
 #    a) This script generates an orography file only on tile 7.
 #

--- a/scripts/exregional_make_orog.sh
+++ b/scripts/exregional_make_orog.sh
@@ -312,7 +312,6 @@ fn_suffix_with_halo="tile${TILE_RGNL}.halo${NHW}.nc"
 raw_orog_fn="${raw_orog_fn_prefix}.${fn_suffix_with_halo}"
 raw_orog_fp="${raw_dir}/${raw_orog_fn}"
 mv_vrfy "${raw_orog_fp_orig}" "${raw_orog_fp}"
-
 #
 #-----------------------------------------------------------------------
 #

--- a/ush/config.nco.sh
+++ b/ush/config.nco.sh
@@ -22,24 +22,12 @@ CYCL_HRS=( "18" )
 EXTRN_MDL_NAME_ICS="FV3GFS"
 EXTRN_MDL_NAME_LBCS="FV3GFS"
 
+#
 # The following must be modified for different platforms and users.
+#
 RUN="an_experiment"
 COMINgfs="/scratch1/NCEPDEV/hwrf/noscrub/hafs-input/COMGFS"     # Path to directory containing files from the external model (FV3GFS).
+FIXLAM_NCO_BASEDIR="/scratch2/BMC/det/FV3LAM_pregen"            # Path to directory containing the pregenerated grid, orography, and surface climatology "fixed" files to use for the experiment.
 STMP="/scratch2/BMC/det/Gerard.Ketefian/UFS_CAM/NCO_dirs/stmp"  # Path to directory STMP that mostly contains input files.
 PTMP="/scratch2/BMC/det/Gerard.Ketefian/UFS_CAM/NCO_dirs/ptmp"  # Path to directory PTMP in which the experiment's output files will be placed.
-
-#
-# In NCO mode, the user must manually (e.g. after doing the build step)
-# create the symlink "${FIXrrfs}/fix_sar" that points to EMC's FIXLAM
-# directory on the machine.  For example, on hera, the symlink's target
-# needs to be
-#
-#   /scratch2/NCEPDEV/fv3-cam/emc.campara/fix_fv3cam/fix_sar
-#
-# The experiment generation script will then set FIXLAM to 
-#
-#   FIXLAM="${FIXrrfs}/fix_lam/${PREDEF_GRID_NAME}"
-#
-# where PREDEF_GRID_NAME has the value set above.
-#
 

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -175,6 +175,19 @@ EXPT_SUBDIR=""
 #
 #   $COMINgfs/gfs.$yyyymmdd/$hh
 #
+# FIXLAM_NCO_BASEDIR:
+# The base directory containing pregenerated grid, orography, and surface 
+# climatology files.  For the pregenerated grid specified by PREDEF_GRID_NAME, 
+# these "fixed" files are located in:
+#
+#   ${FIXLAM_NCO_BASEDIR}/${PREDEF_GRID_NAME}
+#
+# The workflow scripts will create a symlink in the experiment directory
+# that will point to a subdirectory (having the name of the grid being
+# used) under this directory.  This variable should be set to a null 
+# string in this file, but it can be specified in the user-specified 
+# workflow configuration file (EXPT_CONFIG_FN)
+#
 # STMP:
 # The beginning portion of the directory that will contain cycle-dependent
 # model input files, symlinks to cycle-independent input files, and raw 
@@ -214,6 +227,7 @@ EXPT_SUBDIR=""
 #-----------------------------------------------------------------------
 #
 COMINgfs="/base/path/of/directory/containing/gfs/input/files"
+FIXLAM_NCO_BASEDIR=""
 STMP="/base/path/of/directory/containing/model/input/and/raw/output/files"
 NET="rrfs"
 envir="para"

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -407,16 +407,39 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-# Copy fixed files from system directory to the FIXam directory (which
-# is under the experiment directory).  Note that some of these files get
-# renamed during the copy process.
+# Create the FIXam directory under the experiment directory.  In NCO mode,
+# this will be a symlink to the directory specified in FIXgsm, while in
+# community mode, it will be an actual directory with files copied into
+# it from FIXgsm.
 #
 #-----------------------------------------------------------------------
 #
+# First, consider NCO mode.
+#
+if [ "${RUN_ENVIR}" = "nco" ]; then
 
-# In NCO mode, we assume the following copy operation is done beforehand,
-# but that can be changed.
-if [ "${RUN_ENVIR}" != "nco" ]; then
+  ln_vrfy -fsn "$FIXgsm" "$FIXam"
+#
+# Resolve the target directory that the FIXam symlink points to and check 
+# that it exists.
+#
+  path_resolved=$( readlink -m "$FIXam" )
+  if [ ! -d "${path_resolved}" ]; then
+    print_err_msg_exit "\
+In order to be able to generate a forecast experiment in NCO mode (i.e.
+when RUN_ENVIR set to \"nco\"), the path specified by FIXam after resolving
+all symlinks (path_resolved) must be an existing directory (but in this
+case isn't):
+  RUN_ENVIR = \"${RUN_ENVIR}\"
+  FIXam = \"$FIXam\"
+  path_resolved = \"${path_resolved}\"
+Please ensure that path_resolved is an existing directory and then rerun
+the experiment generation script."
+  fi
+#
+# Now consider community mode.
+#
+else
 
   print_info_msg "$VERBOSE" "
 Copying fixed files from system directory (FIXgsm) to a subdirectory

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -190,6 +190,26 @@ fi
 #
 #-----------------------------------------------------------------------
 #
+# Make sure that RUN_TASK_MAKE_OROG is set to a valid value.
+#
+#-----------------------------------------------------------------------
+#
+check_var_valid_value "RUN_TASK_MAKE_OROG" "valid_vals_RUN_TASK_MAKE_OROG"
+#
+# Set RUN_TASK_MAKE_OROG to either "TRUE" or "FALSE" so we don't have to
+# consider other valid values later on.
+#
+RUN_TASK_MAKE_OROG=${RUN_TASK_MAKE_OROG^^}
+if [ "${RUN_TASK_MAKE_OROG}" = "TRUE" ] || \
+   [ "${RUN_TASK_MAKE_OROG}" = "YES" ]; then
+  RUN_TASK_MAKE_OROG="TRUE"
+elif [ "${RUN_TASK_MAKE_OROG}" = "FALSE" ] || \
+     [ "${RUN_TASK_MAKE_OROG}" = "NO" ]; then
+  RUN_TASK_MAKE_OROG="FALSE"
+fi
+#
+#-----------------------------------------------------------------------
+#
 # Make sure that RUN_TASK_MAKE_SFC_CLIMO is set to a valid value.
 #
 #-----------------------------------------------------------------------
@@ -207,28 +227,6 @@ if [ "${RUN_TASK_MAKE_SFC_CLIMO}" = "TRUE" ] || \
 elif [ "${RUN_TASK_MAKE_SFC_CLIMO}" = "FALSE" ] || \
      [ "${RUN_TASK_MAKE_SFC_CLIMO}" = "NO" ]; then
   RUN_TASK_MAKE_SFC_CLIMO="FALSE"
-fi
-#
-# If RUN_TASK_MAKE_SFC_CLIMO is set to "FALSE", make sure that the di-
-# rectory SFC_CLIMO_DIR that should contain the pre-generated surface 
-# climatology files exists.
-#
-if [ "${RUN_TASK_MAKE_SFC_CLIMO}" = "FALSE" ] && \
-   [ ! -d "${SFC_CLIMO_DIR}" ]; then
-  print_err_msg_exit "\
-The directory (SFC_CLIMO_DIR) that should contain the pre-generated sur-
-face climatology files does not exist:
-  SFC_CLIMO_DIR = \"${SFC_CLIMO_DIR}\""
-fi
-#
-# If RUN_TASK_MAKE_SFC_CLIMO is set to "TRUE" and the variable specify-
-# ing the directory in which to look for pregenerated grid and orography
-# files (i.e. SFC_CLIMO_DIR) is not empty, then for clarity reset the 
-# latter to an empty string (because it will not be used).
-#
-if [ "${RUN_TASK_MAKE_SFC_CLIMO}" = "TRUE" ] && \
-   [ -n "${SFC_CLIMO_DIR}" ]; then
-  SFC_CLIMO_DIR=""
 fi
 #
 #-----------------------------------------------------------------------
@@ -660,7 +658,6 @@ SRC_DIR="${SR_WX_APP_TOP_DIR}/src"
 PARMDIR="$HOMErrfs/parm"
 MODULES_DIR="$HOMErrfs/modulefiles"
 EXECDIR="${SR_WX_APP_TOP_DIR}/bin"
-FIXrrfs="$HOMErrfs/fix"
 TEMPLATE_DIR="$USHDIR/templates"
 
 case $MACHINE in
@@ -669,48 +666,56 @@ case $MACHINE in
     FIXgsm=${FIXgsm:-"/gpfs/hps3/emc/global/noscrub/emc.glopara/git/fv3gfs/fix/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/gpfs/hps3/emc/global/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/gpfs/hps3/emc/global/noscrub/emc.glopara/git/fv3gfs/fix/fix_sfc_climo"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/needs/to/be/specified"}
     ;;
 
   "WCOSS_DELL_P3")
     FIXgsm=${FIXgsm:-"/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/gpfs/dell2/emc/modeling/noscrub/emc.glopara/git/fv3gfs/fix/fix_sfc_climo"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/needs/to/be/specified"}
     ;;
 
   "HERA")
     FIXgsm=${FIXgsm:-"/scratch1/NCEPDEV/global/glopara/fix/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/scratch1/NCEPDEV/global/glopara/fix/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/scratch1/NCEPDEV/global/glopara/fix/fix_sfc_climo"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/scratch2/BMC/det/FV3LAM_pregen"}
     ;;
 
   "ORION")
     FIXgsm=${FIXgsm:-"/work/noaa/global/glopara/fix/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/work/noaa/global/glopara/fix/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/work/noaa/global/glopara/fix/fix_sfc_climo"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/needs/to/be/specified"}
     ;;
 
   "JET")
     FIXgsm=${FIXgsm:-"/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/lfs4/HFIP/hfv3gfs/glopara/git/fv3gfs/fix/fix_sfc_climo"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/needs/to/be/specified"}
     ;;
 
   "ODIN")
     FIXgsm=${FIXgsm:-"/scratch/ywang/fix/theia_fix/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/scratch/ywang/fix/theia_fix/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/scratch/ywang/fix/climo_fields_netcdf"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/needs/to/be/specified"}
     ;;
 
   "CHEYENNE")
     FIXgsm=${FIXgsm:-"/glade/p/ral/jntp/UFS_CAM/fix/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/glade/p/ral/jntp/UFS_CAM/fix/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/glade/p/ral/jntp/UFS_CAM/fix/climo_fields_netcdf"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/needs/to/be/specified"}
     ;;
 
   "STAMPEDE")
     FIXgsm=${FIXgsm:-"/work/00315/tg455890/stampede2/regional_fv3/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/work/00315/tg455890/stampede2/regional_fv3/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/work/00315/tg455890/stampede2/regional_fv3/climo_fields_netcdf"}
+    FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/needs/to/be/specified"}
     ;;
 
   *)
@@ -720,6 +725,7 @@ One or more fix file directories have not been specified for this machine:
   FIXgsm = \"${FIXgsm:-\"\"}
   TOPO_DIR = \"${TOPO_DIR:-\"\"}
   SFC_CLIMO_INPUT_DIR = \"${SFC_CLIMO_INPUT_DIR:-\"\"}
+  FIXLAM_NCO_BASEDIR = \"${FIXLAM_NCO_BASEDIR:-\"\"}
 You can specify the missing location(s) in config.sh"
     ;;
 
@@ -894,6 +900,19 @@ fi
 #
 #-----------------------------------------------------------------------
 #
+# Make sure GRID_GEN_METHOD is set to a valid value.
+#
+#-----------------------------------------------------------------------
+#
+err_msg="\
+The horizontal grid generation method specified in GRID_GEN_METHOD is 
+not supported:
+  GRID_GEN_METHOD = \"${GRID_GEN_METHOD}\""
+check_var_valid_value \
+  "GRID_GEN_METHOD" "valid_vals_GRID_GEN_METHOD" "${err_msg}"
+#
+#-----------------------------------------------------------------------
+#
 # For a "GFDLgrid" type of grid, make sure GFDLgrid_RES is set to a valid
 # value.
 #
@@ -998,67 +1017,19 @@ check_for_preexist_dir_file "$EXPTDIR" "${PREEXISTING_DIR_METHOD}"
 #
 LOGDIR="${EXPTDIR}/log"
 
+FIXam="${EXPTDIR}/fix_am"
+FIXLAM="${EXPTDIR}/fix_lam"
+
 if [ "${RUN_ENVIR}" = "nco" ]; then
-
-  FIXam="${FIXrrfs}/fix_am"
-#
-# In NCO mode (i.e. if RUN_ENVIR set to "nco"), it is assumed that before
-# running the experiment generation script, the path specified in FIXam 
-# already exists and is either itself the directory in which various fixed
-# files (but not the ones containing the regional grid and the orography
-# and surface climatology on that grid) are located, or it is a symlink 
-# to such a directory.  Resolve any symlinks in the path specified by 
-# FIXam and check that this is the case.
-#
-  path_resolved=$( readlink -m "$FIXam" )
-  if [ ! -d "${path_resolved}" ]; then
-    print_err_msg_exit "\
-In order to be able to generate a forecast experiment in NCO mode (i.e. 
-when RUN_ENVIR set to \"nco\"), the path specified by FIXam after resolving 
-all symlinks (path_resolved) must be an existing directory (but in this
-case isn't):
-  RUN_ENVIR = \"${RUN_ENVIR}\"
-  FIXam = \"$FIXam\"
-  path_resolved = \"${path_resolved}\"
-Please ensure that path_resolved is an existing directory and then rerun 
-the experiment generation script."
-  fi
-
-  FIXLAM="${FIXrrfs}/fix_lam/${PREDEF_GRID_NAME}"
-#
-# In NCO mode (i.e. if RUN_ENVIR set to "nco"), it is assumed that before
-# running the experiment generation script, the path specified in FIXLAM 
-# already exists and is either itself the directory in which the fixed 
-# grid, orography, and surface climatology files are located, or it is a
-# symlink to such a directory.  Resolve any symlinks in the path specified
-# by FIXLAM and check that this is the case.
-#
-  path_resolved=$( readlink -m "$FIXLAM" )
-  if [ ! -d "${path_resolved}" ]; then
-    print_err_msg_exit "\
-In order to be able to generate a forecast experiment in NCO mode (i.e. 
-when RUN_ENVIR set to \"nco\"), the path specified by FIXLAM after resolving 
-all symlinks (path_resolved) must be an existing directory (but in this
-case isn't):
-  RUN_ENVIR = \"${RUN_ENVIR}\"
-  FIXLAM = \"$FIXLAM\"
-  path_resolved = \"${path_resolved}\"
-Please ensure that path_resolved is an existing directory and then rerun 
-the experiment generation script."
-  fi
 
   CYCLE_BASEDIR="$STMP/tmpnwprd/$RUN"
   check_for_preexist_dir_file "${CYCLE_BASEDIR}" "${PREEXISTING_DIR_METHOD}"
-
   COMROOT="$PTMP/com"
-
   COMOUT_BASEDIR="$COMROOT/$NET/$envir"
   check_for_preexist_dir_file "${COMOUT_BASEDIR}" "${PREEXISTING_DIR_METHOD}"
 
 else
 
-  FIXam="${EXPTDIR}/fix_am"
-  FIXLAM="${EXPTDIR}/fix_lam"
   CYCLE_BASEDIR="$EXPTDIR"
   COMROOT=""
   COMOUT_BASEDIR=""
@@ -1339,28 +1310,49 @@ LOAD_MODULES_RUN_TASK_FP="$USHDIR/load_modules_run_task.sh"
 # RUN_TASK_MAKE_SFC_CLIMO is set to "TRUE") or searched for (if RUN_-
 # TASK_MAKE_SFC_CLIMO is set to "FALSE").
 #
+# First, consider NCO mode.
+#
 #----------------------------------------------------------------------
 #
 if [ "${RUN_ENVIR}" = "nco" ]; then
 
+  nco_fix_dir="${FIXLAM_NCO_BASEDIR}/${PREDEF_GRID_NAME}"
+  if [ ! -d "${nco_fix_dir}" ]; then
+    print_err_msg_exit "\
+The directory (nco_fix_dir) that should contain the pregenerated grid,
+orography, and surface climatology files does not exist:
+  nco_fix_dir = \"${nco_fix_dir}\""
+  fi
+
   if [ "${RUN_TASK_MAKE_GRID}" = "TRUE" ] || \
      [ "${RUN_TASK_MAKE_GRID}" = "FALSE" -a \
-       "${GRID_DIR}" != "$FIXLAM" ]; then
+       "${GRID_DIR}" != "${nco_fix_dir}" ]; then
 
     msg="
-When RUN_ENVIR is set to \"nco\", it is assumed that grid files already
-exist in the directory specified by FIXLAM.  Thus, the grid file genera-
-tion task must not be run (i.e. RUN_TASK_MAKE_GRID must be set to 
-FALSE), and the directory in which to look for the grid files (i.e. 
-GRID_DIR) must be set to FIXLAM.  Current values for these quantities
-are:
+When RUN_ENVIR is set to \"nco\", the workflow assumes that pregenerated
+grid files already exist in the directory 
+
+  \${FIXLAM_NCO_BASEDIR}/\${PREDEF_GRID_NAME}
+
+where
+
+  FIXLAM_NCO_BASEDIR = \"${FIXLAM_NCO_BASEDIR}\"
+  PREDEF_GRID_NAME = \"${PREDEF_GRID_NAME}\"
+
+Thus, the MAKE_GRID_TN task must not be run (i.e. RUN_TASK_MAKE_GRID must 
+be set to \"FALSE\"), and the directory in which to look for the grid 
+files (i.e. GRID_DIR) must be set to the one above.  Current values for 
+these quantities are:
+
   RUN_TASK_MAKE_GRID = \"${RUN_TASK_MAKE_GRID}\"
   GRID_DIR = \"${GRID_DIR}\"
-Resetting RUN_TASK_MAKE_GRID to \"FALSE\" and GRID_DIR to the contents
-of FIXLAM.  Reset values are:"
+
+Resetting RUN_TASK_MAKE_GRID to \"FALSE\" and GRID_DIR to the one above.
+Reset values are:
+"
 
     RUN_TASK_MAKE_GRID="FALSE"
-    GRID_DIR="$FIXLAM"
+    GRID_DIR="${nco_fix_dir}"
 
     msg="$msg""
   RUN_TASK_MAKE_GRID = \"${RUN_TASK_MAKE_GRID}\"
@@ -1368,27 +1360,38 @@ of FIXLAM.  Reset values are:"
 "
 
     print_info_msg "$msg"
-  
+
   fi
 
   if [ "${RUN_TASK_MAKE_OROG}" = "TRUE" ] || \
      [ "${RUN_TASK_MAKE_OROG}" = "FALSE" -a \
-       "${OROG_DIR}" != "$FIXLAM" ]; then
+       "${OROG_DIR}" != "${nco_fix_dir}" ]; then
 
     msg="
-When RUN_ENVIR is set to \"nco\", it is assumed that orography files al-
-ready exist in the directory specified by FIXLAM.  Thus, the orography 
-file generation task must not be run (i.e. RUN_TASK_MAKE_OROG must be 
-set to FALSE), and the directory in which to look for the orography 
-files (i.e. OROG_DIR) must be set to FIXLAM.  Current values for these
-quantities are:
+When RUN_ENVIR is set to \"nco\", the workflow assumes that pregenerated
+orography files already exist in the directory 
+
+  \${FIXLAM_NCO_BASEDIR}/\${PREDEF_GRID_NAME}
+
+where
+
+  FIXLAM_NCO_BASEDIR = \"${FIXLAM_NCO_BASEDIR}\"
+  PREDEF_GRID_NAME = \"${PREDEF_GRID_NAME}\"
+
+Thus, the MAKE_OROG_TN task must not be run (i.e. RUN_TASK_MAKE_OROG must 
+be set to \"FALSE\"), and the directory in which to look for the orography 
+files (i.e. OROG_DIR) must be set to the one above.  Current values for 
+these quantities are:
+
   RUN_TASK_MAKE_OROG = \"${RUN_TASK_MAKE_OROG}\"
   OROG_DIR = \"${OROG_DIR}\"
-Resetting RUN_TASK_MAKE_OROG to \"FALSE\" and OROG_DIR to the contents
-of FIXLAM.  Reset values are:"
+
+Resetting RUN_TASK_MAKE_OROG to \"FALSE\" and OROG_DIR to the one above.
+Reset values are:
+"
 
     RUN_TASK_MAKE_OROG="FALSE"
-    OROG_DIR="$FIXLAM"
+    OROG_DIR="${nco_fix_dir}"
 
     msg="$msg""
   RUN_TASK_MAKE_OROG = \"${RUN_TASK_MAKE_OROG}\"
@@ -1396,27 +1399,38 @@ of FIXLAM.  Reset values are:"
 "
 
     print_info_msg "$msg"
-  
+
   fi
 
   if [ "${RUN_TASK_MAKE_SFC_CLIMO}" = "TRUE" ] || \
      [ "${RUN_TASK_MAKE_SFC_CLIMO}" = "FALSE" -a \
-       "${SFC_CLIMO_DIR}" != "$FIXLAM" ]; then
+       "${SFC_CLIMO_DIR}" != "${nco_fix_dir}" ]; then
 
     msg="
-When RUN_ENVIR is set to \"nco\", it is assumed that surface climatology
-files already exist in the directory specified by FIXLAM.  Thus, the 
-surface climatology file generation task must not be run (i.e. RUN_-
-TASK_MAKE_SFC_CLIMO must be set to FALSE), and the directory in which to
-look for the surface climatology files (i.e. SFC_CLIMO_DIR) must be set
-to FIXLAM.  Current values for these quantities are:
+When RUN_ENVIR is set to \"nco\", the workflow assumes that pregenerated
+surface climatology files already exist in the directory 
+
+  \${FIXLAM_NCO_BASEDIR}/\${PREDEF_GRID_NAME}
+
+where
+
+  FIXLAM_NCO_BASEDIR = \"${FIXLAM_NCO_BASEDIR}\"
+  PREDEF_GRID_NAME = \"${PREDEF_GRID_NAME}\"
+
+Thus, the MAKE_SFC_CLIMO_TN task must not be run (i.e. RUN_TASK_MAKE_SFC_CLIMO 
+must be set to \"FALSE\"), and the directory in which to look for the 
+surface climatology files (i.e. SFC_CLIMO_DIR) must be set to the one 
+above.  Current values for these quantities are:
+
   RUN_TASK_MAKE_SFC_CLIMO = \"${RUN_TASK_MAKE_SFC_CLIMO}\"
   SFC_CLIMO_DIR = \"${SFC_CLIMO_DIR}\"
-Resetting RUN_TASK_MAKE_SFC_CLIMO to \"FALSE\" and SFC_CLIMO_DIR to the
-contents of FIXLAM.  Reset values are:"
+
+Resetting RUN_TASK_MAKE_SFC_CLIMO to \"FALSE\" and SFC_CLIMO_DIR to the 
+one above.  Reset values are:
+"
 
     RUN_TASK_MAKE_SFC_CLIMO="FALSE"
-    SFC_CLIMO_DIR="$FIXLAM"
+    SFC_CLIMO_DIR="${nco_fix_dir}"
 
     msg="$msg""
   RUN_TASK_MAKE_SFC_CLIMO = \"${RUN_TASK_MAKE_SFC_CLIMO}\"
@@ -1424,44 +1438,42 @@ contents of FIXLAM.  Reset values are:"
 "
 
     print_info_msg "$msg"
-  
-  fi
 
+  fi
+#
+#-----------------------------------------------------------------------
+#
+# Now consider community mode.
+#
+#-----------------------------------------------------------------------
+#
 else
 #
-#-----------------------------------------------------------------------
-#
 # If RUN_TASK_MAKE_GRID is set to "FALSE", the workflow will look for 
-# the pre-generated grid files in GRID_DIR.  In this case, make sure 
-# that GRID_DIR exists.  Otherwise, set it to a predefined location un-
-# der the experiment directory (EXPTDIR).
-#
-#-----------------------------------------------------------------------
+# the pregenerated grid files in GRID_DIR.  In this case, make sure that 
+# GRID_DIR exists.  Otherwise, set it to a predefined location under the 
+# experiment directory (EXPTDIR).
 #
   if [ "${RUN_TASK_MAKE_GRID}" = "FALSE" ]; then
     if [ ! -d "${GRID_DIR}" ]; then
       print_err_msg_exit "\
-The directory (GRID_DIR) that should contain the pre-generated grid 
-files does not exist:
+The directory (GRID_DIR) that should contain the pregenerated grid files 
+does not exist:
   GRID_DIR = \"${GRID_DIR}\""
     fi
   else
     GRID_DIR="$EXPTDIR/grid"
   fi
 #
-#-----------------------------------------------------------------------
-#
 # If RUN_TASK_MAKE_OROG is set to "FALSE", the workflow will look for 
-# the pre-generated orography files in OROG_DIR.  In this case, make 
-# sure that OROG_DIR exists.  Otherwise, set it to a predefined location
-# under the experiment directory (EXPTDIR).
-#
-#-----------------------------------------------------------------------
+# the pregenerated orography files in OROG_DIR.  In this case, make sure 
+# that OROG_DIR exists.  Otherwise, set it to a predefined location under 
+# the experiment directory (EXPTDIR).
 #
   if [ "${RUN_TASK_MAKE_OROG}" = "FALSE" ]; then
     if [ ! -d "${OROG_DIR}" ]; then
       print_err_msg_exit "\
-The directory (OROG_DIR) that should contain the pre-generated orography
+The directory (OROG_DIR) that should contain the pregenerated orography
 files does not exist:
   OROG_DIR = \"${OROG_DIR}\""
     fi
@@ -1469,24 +1481,18 @@ files does not exist:
     OROG_DIR="$EXPTDIR/orog"
   fi
 #
-#-----------------------------------------------------------------------
-#
 # If RUN_TASK_MAKE_SFC_CLIMO is set to "FALSE", the workflow will look 
-# for the pre-generated surface climatology files in SFC_CLIMO_DIR.  In
+# for the pregenerated surface climatology files in SFC_CLIMO_DIR.  In
 # this case, make sure that SFC_CLIMO_DIR exists.  Otherwise, set it to
 # a predefined location under the experiment directory (EXPTDIR).
 #
-#-----------------------------------------------------------------------
-#
   if [ "${RUN_TASK_MAKE_SFC_CLIMO}" = "FALSE" ]; then
-
     if [ ! -d "${SFC_CLIMO_DIR}" ]; then
       print_err_msg_exit "\
-The directory (SFC_CLIMO_DIR) that should contain the pre-generated orography
-files does not exist:
+The directory (SFC_CLIMO_DIR) that should contain the pregenerated surface
+climatology files does not exist:
   SFC_CLIMO_DIR = \"${SFC_CLIMO_DIR}\""
     fi
-
   else
     SFC_CLIMO_DIR="$EXPTDIR/sfc_climo"
   fi
@@ -1615,19 +1621,6 @@ NH4=4
 #
 #-----------------------------------------------------------------------
 #
-# Make sure GRID_GEN_METHOD is set to a valid value.
-#
-#-----------------------------------------------------------------------
-#
-err_msg="\
-The horizontal grid generation method specified in GRID_GEN_METHOD is 
-not supported:
-  GRID_GEN_METHOD = \"${GRID_GEN_METHOD}\""
-check_var_valid_value \
-  "GRID_GEN_METHOD" "valid_vals_GRID_GEN_METHOD" "${err_msg}"
-#
-#-----------------------------------------------------------------------
-#
 # Set parameters according to the type of horizontal grid generation me-
 # thod specified.  First consider GFDL's global-parent-grid based me-
 # thod.
@@ -1688,51 +1681,28 @@ fi
 #
 #-----------------------------------------------------------------------
 #
-#
+# Create a new experiment directory.  Note that at this point we are 
+# guaranteed that there is no preexisting experiment directory.
 #
 #-----------------------------------------------------------------------
 #
+mkdir_vrfy -p "$EXPTDIR"
+
+
+#
+#-----------------------------------------------------------------------
+#
+# If not running the MAKE_GRID_TN, MAKE_OROG_TN, and/or MAKE_SFC_CLIMO
+# tasks, create symlinks under the FIXLAM directory to pregenerated grid,
+# orography, and surface climatology files.  In the process, also set 
+# RES_IN_FIXLAM_FILENAMES, which is the resolution of the grid (in units
+# of number of grid points on an equivalent global uniform cubed-sphere
+# grid) used in the names of the fixed files in the FIXLAM directory.
+#
+#-----------------------------------------------------------------------
+#
+mkdir_vrfy -p "$FIXLAM"
 RES_IN_FIXLAM_FILENAMES=""
-
-if [ "${RUN_ENVIR}" != "nco" ]; then
-  mkdir_vrfy -p "$FIXLAM"
-fi
-#
-#-----------------------------------------------------------------------
-#
-#
-#
-#-----------------------------------------------------------------------
-#
-if [ "${RUN_ENVIR}" = "nco" ]; then
-
-  suffix="${DOT_OR_USCORE}mosaic.halo${NH3}.nc"
-  glob_pattern="C*$suffix"
-  cd_vrfy $FIXLAM
-  num_files=$( ls -1 ${glob_pattern} 2>/dev/null | wc -l )
-
-  if [ "${num_files}" -ne "1" ]; then
-    print_err_msg_exit "\
-Exactly one file must exist in directory FIXLAM matching the globbing
-pattern glob_pattern:
-  FIXLAM = \"${FIXLAM}\"
-  glob_pattern = \"${glob_pattern}\"
-  num_files = ${num_files}"
-  fi
-
-  fn=$( ls -1 ${glob_pattern} )
-  RES_IN_FIXLAM_FILENAMES=$( \
-    printf "%s" $fn | sed -n -r -e "s/^C([0-9]*)$suffix/\1/p" )
-  if [ "${GRID_GEN_METHOD}" = "GFDLgrid" ] && \
-     [ "${GFDLgrid_RES}" -ne "${RES_IN_FIXLAM_FILENAMES}" ]; then
-    print_err_msg_exit "\
-The resolution extracted from the fixed file names (RES_IN_FIXLAM_FILENAMES)
-does not match the resolution specified by GFDLgrid_RES:
-  GFDLgrid_RES = ${GFDLgrid_RES}
-  RES_IN_FIXLAM_FILENAMES = ${RES_IN_FIXLAM_FILENAMES}"
-  fi
-
-else
 #
 #-----------------------------------------------------------------------
 #
@@ -1742,19 +1712,19 @@ else
 #
 #-----------------------------------------------------------------------
 #
-  res_in_grid_fns=""
-  if [ "${RUN_TASK_MAKE_GRID}" = "FALSE" ]; then
+res_in_grid_fns=""
+if [ "${RUN_TASK_MAKE_GRID}" = "FALSE" ]; then
 
-    link_fix \
-      verbose="$VERBOSE" \
-      file_group="grid" \
-      output_varname_res_in_filenames="res_in_grid_fns" || \
-    print_err_msg_exit "\
-  Call to function to create links to grid files failed."
+  link_fix \
+    verbose="$VERBOSE" \
+    file_group="grid" \
+    output_varname_res_in_filenames="res_in_grid_fns" || \
+  print_err_msg_exit "\
+Call to function to create links to grid files failed."
 
-    RES_IN_FIXLAM_FILENAMES="${res_in_grid_fns}"
+  RES_IN_FIXLAM_FILENAMES="${res_in_grid_fns}"
 
-  fi
+fi
 #
 #-----------------------------------------------------------------------
 #
@@ -1764,29 +1734,29 @@ else
 #
 #-----------------------------------------------------------------------
 #
-  res_in_orog_fns=""
-  if [ "${RUN_TASK_MAKE_OROG}" = "FALSE" ]; then
+res_in_orog_fns=""
+if [ "${RUN_TASK_MAKE_OROG}" = "FALSE" ]; then
 
-    link_fix \
-      verbose="$VERBOSE" \
-      file_group="orog" \
-      output_varname_res_in_filenames="res_in_orog_fns" || \
+  link_fix \
+    verbose="$VERBOSE" \
+    file_group="orog" \
+    output_varname_res_in_filenames="res_in_orog_fns" || \
+  print_err_msg_exit "\
+Call to function to create links to orography files failed."
+
+  if [ ! -z "${RES_IN_FIXLAM_FILENAMES}" ] && \
+     [ "${res_in_orog_fns}" -ne "${RES_IN_FIXLAM_FILENAMES}" ]; then
     print_err_msg_exit "\
-  Call to function to create links to orography files failed."
-
-    if [ ! -z "${RES_IN_FIXLAM_FILENAMES}" ] && \
-       [ "${res_in_orog_fns}" -ne "${RES_IN_FIXLAM_FILENAMES}" ]; then
-      print_err_msg_exit "\
-  The resolution extracted from the orography file names (res_in_orog_fns)
-  does not match the resolution in other groups of files already consi-
-  dered (RES_IN_FIXLAM_FILENAMES):
-    res_in_orog_fns = ${res_in_orog_fns}
-    RES_IN_FIXLAM_FILENAMES = ${RES_IN_FIXLAM_FILENAMES}"
-    else
-      RES_IN_FIXLAM_FILENAMES="${res_in_orog_fns}"
-    fi
-
+The resolution extracted from the orography file names (res_in_orog_fns)
+does not match the resolution in other groups of files already consi-
+dered (RES_IN_FIXLAM_FILENAMES):
+  res_in_orog_fns = ${res_in_orog_fns}
+  RES_IN_FIXLAM_FILENAMES = ${RES_IN_FIXLAM_FILENAMES}"
+  else
+    RES_IN_FIXLAM_FILENAMES="${res_in_orog_fns}"
   fi
+
+fi
 #
 #-----------------------------------------------------------------------
 #
@@ -1797,28 +1767,26 @@ else
 #
 #-----------------------------------------------------------------------
 #
-  res_in_sfc_climo_fns=""
-  if [ "${RUN_TASK_MAKE_SFC_CLIMO}" = "FALSE" ]; then
+res_in_sfc_climo_fns=""
+if [ "${RUN_TASK_MAKE_SFC_CLIMO}" = "FALSE" ]; then
 
-    link_fix \
-      verbose="$VERBOSE" \
-      file_group="sfc_climo" \
-      output_varname_res_in_filenames="res_in_sfc_climo_fns" || \
+  link_fix \
+    verbose="$VERBOSE" \
+    file_group="sfc_climo" \
+    output_varname_res_in_filenames="res_in_sfc_climo_fns" || \
+  print_err_msg_exit "\
+Call to function to create links to surface climatology files failed."
+
+  if [ ! -z "${RES_IN_FIXLAM_FILENAMES}" ] && \
+     [ "${res_in_sfc_climo_fns}" -ne "${RES_IN_FIXLAM_FILENAMES}" ]; then
     print_err_msg_exit "\
-  Call to function to create links to surface climatology files failed."
-
-    if [ ! -z "${RES_IN_FIXLAM_FILENAMES}" ] && \
-       [ "${res_in_sfc_climo_fns}" -ne "${RES_IN_FIXLAM_FILENAMES}" ]; then
-      print_err_msg_exit "\
-  The resolution extracted from the surface climatology file names (res_-
-  in_sfc_climo_fns) does not match the resolution in other groups of files
-  already considered (RES_IN_FIXLAM_FILENAMES):
-    res_in_sfc_climo_fns = ${res_in_sfc_climo_fns}
-    RES_IN_FIXLAM_FILENAMES = ${RES_IN_FIXLAM_FILENAMES}"
-    else
-      RES_IN_FIXLAM_FILENAMES="${res_in_sfc_climo_fns}"
-    fi
-
+The resolution extracted from the surface climatology file names (res_-
+in_sfc_climo_fns) does not match the resolution in other groups of files
+already considered (RES_IN_FIXLAM_FILENAMES):
+  res_in_sfc_climo_fns = ${res_in_sfc_climo_fns}
+  RES_IN_FIXLAM_FILENAMES = ${RES_IN_FIXLAM_FILENAMES}"
+  else
+    RES_IN_FIXLAM_FILENAMES="${res_in_sfc_climo_fns}"
   fi
 
 fi
@@ -1937,18 +1905,6 @@ fi
 #-----------------------------------------------------------------------
 #
 NNODES_RUN_FCST=$(( (PE_MEMBER01 + PPN_RUN_FCST - 1)/PPN_RUN_FCST ))
-
-#
-#-----------------------------------------------------------------------
-#
-# Create a new experiment directory.  Note that at this point we are 
-# guaranteed that there is no preexisting experiment directory.
-#
-#-----------------------------------------------------------------------
-#
-mkdir_vrfy -p "$EXPTDIR"
-
-
 
 
 
@@ -2291,7 +2247,6 @@ SRC_DIR="$SRC_DIR"
 PARMDIR="$PARMDIR"
 MODULES_DIR="${MODULES_DIR}"
 EXECDIR="$EXECDIR"
-FIXrrfs="$FIXrrfs"
 FIXam="$FIXam"
 FIXLAM="$FIXLAM"
 FIXgsm="$FIXgsm"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES:
### Main changes:
* In NCO mode, remove requirement that there be "fix_am" and "fix_lam" symlinks under a directory named "fix" under "regional_workflow".  Instead, move "fix_am" and "fix_lam" to under the experiment directory, and have "fix_am" be a symlink like before but (for consistency with what is done in community mode) have "fix_lam" be an actual directory (not a symlink) that contains symlinks to files in some other (possibly user-specified) directory.  For this purpose:
  * In setup.sh, set FIXam to $EXPTDIR/fix_am and FIXLAM to $EXPTDIR/fix_lam in both NCO and community modes.
  * For clarity, move creation of the "fix_am" symlink in NCO mode from setup.sh to generate_FV3LAM_wflow.sh, and make it part of the same if-statement in generate_FV3LAM_wflow.sh that creates the "fix_am" directory in community mode.
  * In config_defaults.sh, introduce the new workflow variable FIXLAM_NCO_BASEDIR.  This variable is only used in NCO mode.  It specifies the base directory in which the pregenerated grid, orography, and surface climatology files required in NCO mode are located.  More specifically, we assume that these files are located in the directory 
`${FIXLAM_NCO_BASEDIR}/${PREDEF_GRID_NAME}`
where PREDEF_GRID_NAME specifies the name of the predefined grid being used in NCO mode.  Note that this implies that in NCO mode, only a predefined grid may be used; the user cannot define a custom grid.  This was already a restriction in the workflow but not clearly stated.  A repository issue (#[400](https://github.com/NOAA-EMC/regional_workflow/issues/400)) has been created to relax this restriction.
  * In setup.sh, set platform-dependent default values for FIXLAM_NCO_BASEDIR.  Note that these default values get used only if FIXLAM_NCO_BASEDIR is not specified by the user in the experiment configuration file (config.sh).
  * With the above changes, the creation of symlinks (using the link_fix function) in the "fix_lam" subdirectory under the experiment directory and the setting of the variable RES_IN_FIXLAM_FILENAMES can now be handled in the same way in NCO mode as in community mode.  Thus, remove section of code in setup.sh that sets RES_IN_FIXLAM_FILENAMES specifically in NCO mode, and use the section of code that was previously used only in community mode to create the symlinks and set RES_IN_FIXLAM_FILENAMES in both NCO and community modes.
* Remove check near the top of setup.sh on existence of SFC_CLIMO_DIR when RUN_TASK_MAKE_SFC_CLIMO is set to "FALSE" because this test is in effect now performed later in the script, both in NCO and community modes.
* In setup.sh, for simplicity remove setting of SFC_CLIMO_DIR to a null string when RUN_TASK_MAKE_SFC_CLIMO is set to "TRUE" and SFC_CLIMO_DIR is not already a null string because the same is not done for GRID_DIR and OROG_DIR.
* For the purpose of running the WE2E tests, in run_experiments.sh:
  * If the test is to be run in NCO mode, set the variable FIXLAM_NCO_BASEDIR and add it to the configuration file that the script generates.
  * In both NCO and community modes, assume that when using pregenerated grid, orography, and/or surface climatology files (i.e. when RUN_TASK_MAKE_GRID, RUN_TASK_MAKE_OROG, and/or RUN_TASK_MAKE_SFC_CLIMO are set to "FALSE"), the files are located directly under the ${PREDEF_GRID_NAME} subdirectory of some specified base directory.  Thus, in run_experiments.sh, create a new variable called pregen_basedir and append to it ${PREDEF_GRID_NAME} as necessary to set GRID_DIR, OROG_DIR, and/or SFC_CLIMO_DIR and remove the "grid", "orog", and "sfc_climo" subdirectories in the settings of these three variables.  Note that this is only for the WE2E testing system.  In community mode, users can still specify (in config.sh) independent directories for GRID_DIR, OROG_DIR, and SFC_CLIMO_DIR when using pregenerated fixed files.  In NCO mode, the fixed files need to be located in ${FIXLAM_NCO_BASEDIR}/${PREDEF_GRID_NAME}" (in NCO mode, the experiment generation scripts will ensure that GRID_DIR, OROG_DIR, and SFC_CLIMO_DIR are all set to this).
* In the sample NCO mode workflow configuration file config.nco.sh, add the variable FIXLAM_NCO_BASEDIR (for a valid value on Hera only; values are platform and user dependent).

### Improvements:
* Add missing code that checks that RUN_TASK_MAKE_OROG is set to a valid value (just like there is code to check that RUN_TASK_MAKE_GRID and RUN_TASK_MAKE_SFC_CLIMO are set to valid values).
* Move the code in setup.sh that checks that GRID_GEN_METHOD is set to a valid value to an earlier location in the file.
* Edit error messages in setup.sh to make them more accurate and clearer.
* Clean up comments.

## TESTS CONDUCTED:
Ran the following WE2E tests on Hera:
* nco_CONUS_25km_GFDLgrid
* nco_RRFS_CONUS_25km_HRRR_RAP
* pregen_grid_orog_sfc_climo
* regional_002