### PR TITLE
Updates to static file structure and naming on Cheyenne.

### DIFF
--- a/modulefiles/tasks/cheyenne/make_grid.local
+++ b/modulefiles/tasks/cheyenne/make_grid.local
@@ -1,6 +1,6 @@
 #%Module
 if [module-info mode load] {
-  system "ncar_pylib /glade/p/ral/jntp/UFS_CAM/ncar_pylib_20200427"
+  system "ncar_pylib /glade/p/ral/jntp/UFS_SRW_app/ncar_pylib/regional_workflow"
 }
 
 if [module-info mode remove] {

--- a/modulefiles/tasks/cheyenne/make_ics.local
+++ b/modulefiles/tasks/cheyenne/make_ics.local
@@ -1,6 +1,6 @@
 #%Module
 if [module-info mode load] {
-  system "ncar_pylib /glade/p/ral/jntp/UFS_CAM/ncar_pylib_20200427"
+  system "ncar_pylib /glade/p/ral/jntp/UFS_SRW_app/ncar_pylib/regional_workflow"
 }
 
 if [module-info mode remove] {

--- a/modulefiles/tasks/cheyenne/make_lbcs.local
+++ b/modulefiles/tasks/cheyenne/make_lbcs.local
@@ -1,6 +1,6 @@
 #%Module
 if [module-info mode load] {
-  system "ncar_pylib /glade/p/ral/jntp/UFS_CAM/ncar_pylib_20200427"
+  system "ncar_pylib /glade/p/ral/jntp/UFS_SRW_app/ncar_pylib/regional_workflow"
 }
 
 if [module-info mode remove] {

--- a/modulefiles/tasks/cheyenne/run_fcst.local
+++ b/modulefiles/tasks/cheyenne/run_fcst.local
@@ -1,6 +1,6 @@
 #%Module
 if [module-info mode load] {
-  system "ncar_pylib /glade/p/ral/jntp/UFS_CAM/ncar_pylib_20200427"
+  system "ncar_pylib /glade/p/ral/jntp/UFS_SRW_app/ncar_pylib/regional_workflow"
 }
 
 if [module-info mode remove] {

--- a/tests/run_experiments.sh
+++ b/tests/run_experiments.sh
@@ -496,7 +496,7 @@ VERBOSE=\"${VERBOSE}\""
     if [ "$MACHINE" = "HERA" ]; then
       pregen_basedir="/scratch2/BMC/det/FV3LAM_pregen"
     elif [ "$MACHINE" = "CHEYENNE" ]; then
-      pregen_basedir="/glade/p/ral/jntp/UFS_CAM/FV3LAM_pregen"
+      pregen_basedir="/glade/p/ral/jntp/UFS_SRW_app/FV3LAM_pregen"
     else
       print_err_msg_exit "\
 The base directory (pregen_basedir) in which the pregenerated grid,
@@ -515,7 +515,7 @@ specified for this machine (MACHINE):
     if [ "$MACHINE" = "HERA" ]; then
       GRID_DIR="/scratch2/BMC/det/FV3LAM_pregen/grid/${PREDEF_GRID_NAME}"
     elif [ "$MACHINE" = "CHEYENNE" ]; then
-      GRID_DIR="/glade/p/ral/jntp/UFS_CAM/FV3LAM_pregen/grid/${PREDEF_GRID_NAME}"
+      GRID_DIR="/glade/p/ral/jntp/UFS_SRW_app/FV3LAM_pregen/grid/${PREDEF_GRID_NAME}"
     else
       print_err_msg_exit "\
 The directory (GRID_DIR) in which the pregenerated grid files are located
@@ -538,7 +538,7 @@ GRID_DIR=\"${GRID_DIR}\""
     if [ "$MACHINE" = "HERA" ]; then
       OROG_DIR="/scratch2/BMC/det/FV3LAM_pregen/orog/${PREDEF_GRID_NAME}"
     elif [ "$MACHINE" = "CHEYENNE" ]; then
-      OROG_DIR="/glade/p/ral/jntp/UFS_CAM/FV3LAM_pregen/orog/${PREDEF_GRID_NAME}"
+      OROG_DIR="/glade/p/ral/jntp/UFS_SRW_app/FV3LAM_pregen/orog/${PREDEF_GRID_NAME}"
     else
       print_err_msg_exit "\
 The directory (OROG_DIR) in which the pregenerated grid files are located
@@ -561,7 +561,7 @@ OROG_DIR=\"${OROG_DIR}\""
     if [ "$MACHINE" = "HERA" ]; then
       SFC_CLIMO_DIR="/scratch2/BMC/det/FV3LAM_pregen/sfc_climo/${PREDEF_GRID_NAME}"
     elif [ "$MACHINE" = "CHEYENNE" ]; then
-      SFC_CLIMO_DIR="/glade/p/ral/jntp/UFS_CAM/FV3LAM_pregen/sfc_climo/${PREDEF_GRID_NAME}"
+      SFC_CLIMO_DIR="/glade/p/ral/jntp/UFS_SRW_app/FV3LAM_pregen/sfc_climo/${PREDEF_GRID_NAME}"
     else
       print_err_msg_exit "\
 The directory (SFC_CLIMO_DIR) in which the pregenerated grid files are
@@ -705,7 +705,7 @@ PTMP=\"${PTMP}\""
     elif [ "$MACHINE" = "JET" ]; then
       extrn_mdl_source_basedir="/mnt/lfs1/BMC/fim/Gerard.Ketefian/UFS_CAM/staged_extrn_mdl_files"
     elif [ "$MACHINE" = "CHEYENNE" ]; then
-      extrn_mdl_source_basedir="/glade/p/ral/jntp/UFS_CAM/staged_extrn_mdl_files"
+      extrn_mdl_source_basedir="/glade/p/ral/jntp/UFS_SRW_app/staged_extrn_mdl_files"
     elif [ "$MACHINE" = "ORION" ]; then
       extrn_mdl_source_basedir="/work/noaa/gsd-fv3-dev/gsketefia/UFS/staged_extrn_mdl_files"
     else

--- a/ush/set_extrn_mdl_params.sh
+++ b/ush/set_extrn_mdl_params.sh
@@ -72,7 +72,7 @@ else
       EXTRN_MDL_SYSBASEDIR_ICS="/scratch/ywang/EPIC/GDAS/2019053000_mem001"
       ;;
     "CHEYENNE")
-      EXTRN_MDL_SYSBASEDIR_ICS="/glade/p/ral/jntp/UFS_CAM/COMGFS"
+      EXTRN_MDL_SYSBASEDIR_ICS="/glade/p/ral/jntp/UFS_SRW_app/COMGFS"
       ;;
     "STAMPEDE")
       EXTRN_MDL_SYSBASEDIR_ICS="/scratch/00315/tg455890/GDAS/20190530/2019053000_mem001"
@@ -104,7 +104,7 @@ else
       EXTRN_MDL_SYSBASEDIR_ICS="/scratch/00315/tg455890/GDAS/20190530/2019053000_mem001"
       ;;
     "CHEYENNE")
-      EXTRN_MDL_SYSBASEDIR_ICS="/glade/p/ral/jntp/UFS_CAM/COMGFS"
+      EXTRN_MDL_SYSBASEDIR_ICS="/glade/p/ral/jntp/UFS_SRW_app/COMGFS"
       ;;
     esac
     ;;
@@ -226,7 +226,7 @@ else
       EXTRN_MDL_SYSBASEDIR_LBCS="/scratch/ywang/EPIC/GDAS/2019053000_mem001"
       ;;
     "CHEYENNE")
-      EXTRN_MDL_SYSBASEDIR_LBCS="/glade/p/ral/jntp/UFS_CAM/COMGFS"
+      EXTRN_MDL_SYSBASEDIR_LBCS="/glade/p/ral/jntp/UFS_SRW_app/COMGFS"
       ;;
     "STAMPEDE")
       EXTRN_MDL_SYSBASEDIR_LBCS="/scratch/00315/tg455890/GDAS/20190530/2019053000_mem001"
@@ -255,7 +255,7 @@ else
       EXTRN_MDL_SYSBASEDIR_LBCS="/scratch/ywang/test_runs/FV3_regional/gfs"
       ;;
     "CHEYENNE")
-      EXTRN_MDL_SYSBASEDIR_LBCS="/glade/p/ral/jntp/UFS_CAM/COMGFS"
+      EXTRN_MDL_SYSBASEDIR_LBCS="/glade/p/ral/jntp/UFS_SRW_app/COMGFS"
       ;;
     "STAMPEDE")
       EXTRN_MDL_SYSBASEDIR_LBCS="/scratch/00315/tg455890/GDAS/20190530/2019053000_mem001"

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -702,9 +702,9 @@ case $MACHINE in
     ;;
 
   "CHEYENNE")
-    FIXgsm=${FIXgsm:-"/glade/p/ral/jntp/UFS_CAM/fix/fix_am"}
-    TOPO_DIR=${TOPO_DIR:-"/glade/p/ral/jntp/UFS_CAM/fix/fix_orog"}
-    SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/glade/p/ral/jntp/UFS_CAM/fix/climo_fields_netcdf"}
+    FIXgsm=${FIXgsm:-"/glade/p/ral/jntp/UFS_SRW_app/fix/fix_am"}
+    TOPO_DIR=${TOPO_DIR:-"/glade/p/ral/jntp/UFS_SRW_app/fix/fix_orog"}
+    SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/glade/p/ral/jntp/UFS_SRW_app/fix/climo_fields_netcdf"}
     ;;
 
   "STAMPEDE")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
A few updates are needed to the static input and environment setup files for the SRW on Cheyenne. The static files are now located under the `/glade/p/ral/jntp/UFS_SRW_app/` directory rather than the `/glade/p/ral/jntp/UFS_CAM` directory to conform with the latest naming conventions. The python environment has also been renamed to "regional_workflow" to conform with the naming convention of the conda environments on NOAA HPC platforms.

## TESTS CONDUCTED: 
Ran the release suite of end-to-end tests (`tests/testlist.release_public_v1.txt`) and all passed. A few of these were actually previously broken on Cheyenne, and now run to completion successfully.

The only changes here are to Cheyenne-specific code, but I also ran the release suite on Hera as a sanity check (all passed). 


