### PR TITLE
release/public-v1: modify 'ush/load_modules_run_task.sh' to change the file names of README.txt in the SRW App

### DIFF
--- a/ush/load_modules_run_task.sh
+++ b/ush/load_modules_run_task.sh
@@ -153,8 +153,8 @@ jjob_fp="$2"
 #-----------------------------------------------------------------------
 #
 machine=${MACHINE,,}
-env_fn="README_${machine}_${COMPILER}.txt"
-env_fp="${SR_WX_APP_TOP_DIR}/docs/${env_fn}"
+env_fn="build_${machine}_${COMPILER}.env"
+env_fp="${SR_WX_APP_TOP_DIR}/env/${env_fn}"
 source "${env_fp}" || print_err_msg_exit "\
 Sourcing platform- and compiler-specific environment file (env_fp) for the 
 workflow task specified by task_name failed:

--- a/ush/load_modules_run_task.sh
+++ b/ush/load_modules_run_task.sh
@@ -147,7 +147,7 @@ jjob_fp="$2"
 #
 #-----------------------------------------------------------------------
 #
-# Sourcing ufs-srweather-app README file (in directory specified by mod-
+# Sourcing ufs-srweather-app build-environment file (in directory specified by mod-
 # ules_dir) for the specified task
 #
 #-----------------------------------------------------------------------


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 
The script 'load_modules_run_task.sh' in the 'regional_workflow/ush' directory is modified to change the file names of the 'README_[machine].txt' files.

## TESTS CONDUCTED: 
The modified one was tested on the WCOSS Dell and Cray as well as on Hera.

## ISSUE:
- Fixes the issue mentioned in #407.
- Dependency:  https://github.com/ufs-community/ufs-srweather-app/issues/88
