### PR TITLE
Improve the way LSM-related parameters are set.

### DIFF
--- a/scripts/exregional_make_lbcs.sh
+++ b/scripts/exregional_make_lbcs.sh
@@ -274,22 +274,33 @@ input_type=""
 tracers_input="\"\""
 tracers="\"\""
 #
-# If the physics suite uses Thompson microphysics and if the external 
-# model for LBCs is one that does not provide the aerosol fields needed 
-# by Thompson microphysics (currently only the HRRR and RAP provide
-# aerosol data), set the variable thomp_mp_climo_file in the chgres_cube 
-# namelist to the full path of the file containing aerosol climatology 
-# data.  In this case, this file will be used to generate approximate 
-# aerosol fields in the LBCs that Thompson MP can use.  Otherwise, set 
+#-----------------------------------------------------------------------
+#
+# If the external model for LBCs is one that does not provide the aerosol
+# fields needed by Thompson microphysics (currently only the HRRR and
+# RAP provide aerosol data) and if the physics suite uses Thompson
+# microphysics, set the variable thomp_mp_climo_file in the chgres_cube
+# namelist to the full path of the file containing aerosol climatology
+# data.  In this case, this file will be used to generate approximate
+# aerosol fields in the LBCs that Thompson MP can use.  Otherwise, set
 # thomp_mp_climo_file to a null string.
 #
+#-----------------------------------------------------------------------
+#
 thomp_mp_climo_file=""
-if [ "${THOMPSON_MP_USED}" = "TRUE" ] && \
-   [ "${EXTRN_MDL_NAME_LBCS}" != "HRRR" -a \
-     "${EXTRN_MDL_NAME_LBCS}" != "RAP" ]; then
+if [ "${EXTRN_MDL_NAME_LBCS}" != "HRRR" -a \
+     "${EXTRN_MDL_NAME_LBCS}" != "RAP" ] && \
+   [ "${SDF_USES_THOMPSON_MP}" = "TRUE" ]; then
   thomp_mp_climo_file="${THOMPSON_MP_CLIMO_FP}"
 fi
-
+#
+#-----------------------------------------------------------------------
+#
+# Set other chgres_cube namelist variables depending on the external
+# model used.
+#
+#-----------------------------------------------------------------------
+#
 case "${EXTRN_MDL_NAME_LBCS}" in
 
 "GSMGFS")

--- a/ush/check_ruc_lsm.sh
+++ b/ush/check_ruc_lsm.sh
@@ -1,0 +1,120 @@
+#
+#-----------------------------------------------------------------------
+#
+# This file defines a function that checks whether the RUC land surface
+# model (LSM) parameterization is being called by the selected physics
+# suite.  If so, it sets the variable ruc_lsm used to "TRUE".  If not, 
+# it sets this variable to "FALSE".  It then "returns" this variable, 
+# i.e. it sets the environment variable whose name is specified by the 
+# input argument output_varname_sdf_uses_ruc_lsm to whatever sdf_uses_ruc_lsm 
+# is set to.
+#
+#-----------------------------------------------------------------------
+#
+function check_ruc_lsm() {
+#
+#-----------------------------------------------------------------------
+#
+# Save current shell options (in a global array).  Then set new options
+# for this script/function.
+#
+#-----------------------------------------------------------------------
+#
+  { save_shell_opts; set -u -x; } > /dev/null 2>&1
+#
+#-----------------------------------------------------------------------
+#
+# Get the full path to the file in which this script/function is located 
+# (scrfunc_fp), the name of that file (scrfunc_fn), and the directory in
+# which the file is located (scrfunc_dir).
+#
+#-----------------------------------------------------------------------
+#
+  local scrfunc_fp=$( readlink -f "${BASH_SOURCE[0]}" )
+  local scrfunc_fn=$( basename "${scrfunc_fp}" )
+  local scrfunc_dir=$( dirname "${scrfunc_fp}" )
+#
+#-----------------------------------------------------------------------
+#
+# Get the name of this function.
+#
+#-----------------------------------------------------------------------
+#
+  local func_name="${FUNCNAME[0]}"
+#
+#-----------------------------------------------------------------------
+#
+# Specify the set of valid argument names for this script/function.  Then
+# process the arguments provided to this script/function (which should 
+# consist of a set of name-value pairs of the form arg1="value1", etc).
+#
+#-----------------------------------------------------------------------
+#
+  local valid_args=( \
+    "ccpp_phys_suite_fp" \
+    "output_varname_sdf_uses_ruc_lsm" \
+    )
+  process_args valid_args "$@"
+#
+#-----------------------------------------------------------------------
+#
+# For debugging purposes, print out values of arguments passed to this
+# script.  Note that these will be printed out only if VERBOSE is set to
+# TRUE.
+#
+#-----------------------------------------------------------------------
+#
+  print_input_args valid_args
+#
+#-----------------------------------------------------------------------
+#
+# Declare local variables.
+#
+#-----------------------------------------------------------------------
+#
+  local ruc_lsm_name \
+        regex_search \
+        ruc_lsm_name_or_null \
+        sdf_uses_ruc_lsm
+#
+#-----------------------------------------------------------------------
+#
+# Check the suite definition file to see whether the Thompson microphysics
+# parameterization is being used.
+#
+#-----------------------------------------------------------------------
+#
+  ruc_lsm_name="lsm_ruc"
+  regex_search="^[ ]*<scheme>(${ruc_lsm_name})<\/scheme>[ ]*$"
+  ruc_lsm_name_or_null=$( sed -r -n -e "s/${regex_search}/\1/p" "${ccpp_phys_suite_fp}" )
+
+  if [ "${ruc_lsm_name_or_null}" = "${ruc_lsm_name}" ]; then
+    sdf_uses_ruc_lsm="TRUE"
+  elif [ -z "${ruc_lsm_name_or_null}" ]; then
+    sdf_uses_ruc_lsm="FALSE"
+  else
+    print_err_msg_exit "\
+Unexpected value returned for ruc_lsm_name_or_null:
+  ruc_lsm_name_or_null = \"${ruc_lsm_name_or_null}\"
+This variable should be set to either \"${ruc_lsm_name}\" or an empty
+string."
+  fi
+#
+#-----------------------------------------------------------------------
+#
+# Set output variables.
+#
+#-----------------------------------------------------------------------
+#
+  eval ${output_varname_sdf_uses_ruc_lsm}="${sdf_uses_ruc_lsm}"
+#
+#-----------------------------------------------------------------------
+#
+# Restore the shell options saved at the beginning of this script/function.
+#
+#-----------------------------------------------------------------------
+#
+  { restore_shell_opts; } > /dev/null 2>&1
+
+}
+

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -509,38 +509,34 @@ npx=$((NX+1))
 npy=$((NY+1))
 #
 # For the physics suites that use RUC LSM, set the parameter kice to 9,
-# and set the parameter lsoil according to the external models used for
-# generating the ICs.
+# Otherwise, leave it unspecified (which means it gets set to the default
+# value in the forecast model).
+#
+# NOTE:
+# May want to remove kice from FV3.input.yml (and maybe input.nml.FV3).
 #
 kice=""
 if [ "${SDF_USES_RUC_LSM}" = "TRUE" ]; then
-
   kice="9"
-
-# Is lsoil needed at all?  It may be a variable that is not used in FV3
-# if CCPP is being used.  There may be other variables that supersede it
-# when using CCPP (which is now all the time), like lsoil_lsm.  Check 
-# into this.
-# Also, possibly remove from FV3.input.yml (and maybe input.nml.FV3) the
-# variables set here, like kice, lsoil, etc.
-  if [ "${EXTRN_MDL_NAME_ICS}" = "NAM" ] || \
-     [ "${EXTRN_MDL_NAME_ICS}" = "GSMGFS" ] || \
-     [ "${EXTRN_MDL_NAME_ICS}" = "FV3GFS" ]; then
-    lsoil=4
-  elif [ "${EXTRN_MDL_NAME_ICS}" = "RAP" ] || \
-       [ "${EXTRN_MDL_NAME_ICS}" = "HRRR" ]; then
-    lsoil=9
-  else
-    print_err_msg_exit "\
-The value to set the variable lsoil to in the FV3 namelist file (FV3_NML_FP)
-has not been specified for the following combination of physics suite and
-external model for ICs:
-  CCPP_PHYS_SUITE = \"${CCPP_PHYS_SUITE}\"
-  EXTRN_MDL_NAME_ICS = \"${EXTRN_MDL_NAME_ICS}\"
-Please change one or more of these parameters or provide a value for lsoil
-(and change workflow generation script(s) accordingly) and rerun."
-  fi
-
+fi
+#
+# Set lsoil, which is the number of input soil levels provided in the 
+# chgres_cube output NetCDF file.  This is the same as the parameter 
+# nsoill_out in the namelist file for chgres_cube.  [On the other hand, 
+# the parameter lsoil_lsm (not set here but set in input.nml.FV3 and/or 
+# FV3.input.yml) is the number of soil levels that the LSM scheme in the
+# forecast model will run with.]  Here, we use the same approach to set
+# lsoil as the one used to set nsoill_out in exregional_make_ics.sh.  
+# See that script for details.
+#
+# NOTE:
+# May want to remove lsoil from FV3.input.yml (and maybe input.nml.FV3).
+#
+lsoil="4"
+if [ "${EXTRN_MDL_NAME_ICS}" = "HRRR" -o \
+     "${EXTRN_MDL_NAME_ICS}" = "RAP" ] && \
+   [ "${SDF_USES_RUC_LSM}" = "TRUE" ]; then
+  lsoil="9"
 fi
 #
 # Create a multiline variable that consists of a yaml-compliant string

--- a/ush/set_thompson_mp_fix_files.sh
+++ b/ush/set_thompson_mp_fix_files.sh
@@ -3,9 +3,9 @@
 #
 # This file defines a function that first checks whether the Thompson
 # microphysics parameterization is being called by the selected physics
-# suite.  If not, it sets the output variable specified by
-# output_varname_thompson_mp_used to "FALSE" and exits.  If so, it sets
-# this variable to "TRUE" and modifies the workflow arrays
+# suite.  If not, it sets the output variable whose name is specified by
+# output_varname_sdf_uses_thompson_mp to "FALSE" and exits.  If so, it 
+# sets this variable to "TRUE" and modifies the workflow arrays
 # FIXgsm_FILES_TO_COPY_TO_FIXam and CYCLEDIR_LINKS_TO_FIXam_FILES_MAPPING
 # to ensure that fixed files needed by the Thompson microphysics
 # parameterization are copied to the FIXam directory and that appropriate
@@ -55,7 +55,7 @@ function set_thompson_mp_fix_files() {
   local valid_args=( \
     "ccpp_phys_suite_fp" \
     "thompson_mp_climo_fn" \
-    "output_varname_thompson_mp_used" \
+    "output_varname_sdf_uses_thompson_mp" \
     )
   process_args valid_args "$@"
 #
@@ -78,7 +78,7 @@ function set_thompson_mp_fix_files() {
   local thompson_mp_name \
         regex_search \
         thompson_mp_name_or_null \
-        thompson_mp_used \
+        sdf_uses_thompson_mp \
         thompson_mp_fix_files \
         num_files \
         mapping \
@@ -96,9 +96,9 @@ function set_thompson_mp_fix_files() {
   thompson_mp_name_or_null=$( sed -r -n -e "s/${regex_search}/\1/p" "${ccpp_phys_suite_fp}" )
 
   if [ "${thompson_mp_name_or_null}" = "${thompson_mp_name}" ]; then
-    thompson_mp_used="TRUE"
+    sdf_uses_thompson_mp="TRUE"
   elif [ -z "${thompson_mp_name_or_null}" ]; then
-    thompson_mp_used="FALSE"
+    sdf_uses_thompson_mp="FALSE"
   else
     print_err_msg_exit "\
 Unexpected value returned for thompson_mp_name_or_null:
@@ -113,7 +113,7 @@ string."
 #
 #-----------------------------------------------------------------------
 #
-  if [ "${thompson_mp_used}" = "TRUE" ]; then
+  if [ "${sdf_uses_thompson_mp}" = "TRUE" ]; then
 #
 #-----------------------------------------------------------------------
 #
@@ -176,7 +176,7 @@ values of these parameters are as follows:
 #
 #-----------------------------------------------------------------------
 #
-  eval ${output_varname_thompson_mp_used}="${thompson_mp_used}"
+  eval ${output_varname_sdf_uses_thompson_mp}="${sdf_uses_thompson_mp}"
 #
 #-----------------------------------------------------------------------
 #

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -63,6 +63,7 @@ cd_vrfy ${scrfunc_dir}
 . ./link_fix.sh
 . ./set_ozone_param.sh
 . ./set_thompson_mp_fix_files.sh
+. ./check_ruc_lsm.sh
 #
 #-----------------------------------------------------------------------
 #
@@ -1953,7 +1954,18 @@ fi
 NNODES_RUN_FCST=$(( (PE_MEMBER01 + PPN_RUN_FCST - 1)/PPN_RUN_FCST ))
 
 
-
+#
+#-----------------------------------------------------------------------
+#
+# Call the function that checks whether the RUC land surface model (LSM)
+# is being called by the physics suite and sets the workflow variable 
+# SDF_USES_RUC_LSM to "TRUE" or "FALSE" accordingly.
+#
+#-----------------------------------------------------------------------
+#
+check_ruc_lsm \
+  ccpp_phys_suite_fp="${CCPP_PHYS_SUITE_IN_CCPP_FP}" \
+  output_varname_sdf_uses_ruc_lsm="SDF_USES_RUC_LSM"
 #
 #-----------------------------------------------------------------------
 #
@@ -1977,15 +1989,15 @@ THOMPSON_MP_CLIMO_FP="$FIXam/${THOMPSON_MP_CLIMO_FN}"
 # to ensure that fixed files needed by this parameterization are copied
 # to the FIXam directory and appropriate symlinks to them are created in
 # the run directories.  This function also sets the workflow variable
-# THOMPSON_MP_USED that indicates whether Thompson MP is called by the
-# physics suite.
+# SDF_USES_THOMPSON_MP that indicates whether Thompson MP is called by 
+# the physics suite.
 #
 #-----------------------------------------------------------------------
 #
 set_thompson_mp_fix_files \
   ccpp_phys_suite_fp="${CCPP_PHYS_SUITE_IN_CCPP_FP}" \
   thompson_mp_climo_fn="${THOMPSON_MP_CLIMO_FN}" \
-  output_varname_thompson_mp_used="THOMPSON_MP_USED"
+  output_varname_sdf_uses_thompson_mp="SDF_USES_THOMPSON_MP"
 #
 #-----------------------------------------------------------------------
 #
@@ -2379,7 +2391,8 @@ THOMPSON_MP_CLIMO_FP="${THOMPSON_MP_CLIMO_FP}"
 #
 #-----------------------------------------------------------------------
 #
-THOMPSON_MP_USED="${THOMPSON_MP_USED}"
+SDF_USES_RUC_LSM="${SDF_USES_RUC_LSM}"
+SDF_USES_THOMPSON_MP="${SDF_USES_THOMPSON_MP}"
 #
 #-----------------------------------------------------------------------
 #


### PR DESCRIPTION
## NOTE:
PR #[94](https://github.com/ufs-community/ufs-srweather-app/pull/94) into ufs-srweather-app should be merged right after this PR.

## DESCRIPTION OF CHANGES:
### Main Changes:
* Add the new function check_ruc_lsm.sh that reads in the SDF to check whether it uses the RUC LSM.  If so, it sets the local variable sdf_uses_ruc_lsm to "TRUE", otherwise to "FALSE".  It then sets the environment variable whose name is specified by the input argument output_varname_sdf_uses_ruc_lsm to the value of sdf_uses_ruc_lsm.
* In setup.sh, introduce new workflow variable SDF_USES_RUC_LSM by passing its name as an argument to the new function check_ruc_lsm.sh.  This gets set to "TRUE" if the physics suite uses the RUC LSM and "FALSE" otherwise.
* In exregional_make_ics.sh, set the chgres_cube namelist variable nsoill_out (which is the number of soil levels to have in the NetCDF file that chgres_cube generates) by uisng an if-statement that checks the new workflow variable SDF_USES_RUC_LSM as well as the name of the external model used for ICs.  This if-statemnt replaces the settings of nsoill_out in the external-model-dependent case-statement and, depending on model, the physics-suite-dependent if-statements within that case statement.  This simplifies the script because we no longer need to remember which suites use the RUC LSM and which don't.
* In generate_FV3LAM_wflow.sh, set the number of ice levels in the FV3 input file according to whether the RUC_LSM is used in the physics suite (i.e. by checking the new variable SDF_USES_RUC_LSM).

### Improvements:
* Change the name of the workflow variable THOMPSON_MP_USED to SDF_USES_THOMPSON_MP to be consistent with the new varable SDF_USES_RUC_LSM.
* In set_thompson_mp_fix_files.sh, change the local variable thompson_mp_used to sdf_uses_thompson_mp (to be consistent with the change in the corresponding workflow variable SDF_USES_THOMPSON_MP).

## TESTS CONDUCTED:
Ran the following WE2E tests on Hera using the HEAD (hash #ea8a7aa) of the authoritative ufs-community/ufs-weather-model repo:

* grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
* grid_RRFS_CONUS_13km_ics_HRRR_lbcs_RAP_suite_GSD_SAR_2020020800
* grid_RRFS_CONUS_13km_ics_HRRR_lbcs_RAP_suite_RRFS_v1beta
* grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
* grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GSD_SAR
* grid_RRFS_CONUS_25km_ics_HRRR_lbcs_RAP_suite_GSD_SAR_2020020800
* grid_RRFS_CONUS_25km_ics_HRRR_lbcs_RAP_suite_RRFS_v1beta
* grid_RRFS_CONUS_25km_modify_DT_ATMOS_LAYOUT_XY_BLOCKSIZE
* grid_RRFS_CONUS_3km_ics_HRRR_lbcs_RAP_suite_GSD_SAR_2020020800
* grid_RRFS_CONUS_3km_ics_HRRR_lbcs_RAP_suite_RRFS_v1beta
* nco_CONUS_25km_GFDLgrid
* nco_RRFS_CONUS_25km_HRRR_RAP
* suite_FV3_GSD_v0

All tests were successful.  Note that the three tests whose names end with "_2020020800" are not in the workflow, but they are generated by taking the respective WE2E tests in the workflow with names without the trailing "_2020020800" and simply changing DATE_FIRST_CYCL and DATE_LAST_CYCL from 20200801 to 20200208 and LBC_SPEC_INTVL_HRS from 3 to 1.  The change in date was to try out a winter case, which was the situation under which failures were common (the setting of kice to 9 for suites that use the RUC LSM seems to have fixed this winter case problem).
