### PR TITLE
release/public-v1: Remove setting PS1 from modulefiles/tasks/gaea/*.local

### DIFF
--- a/modulefiles/tasks/gaea/make_grid.local
+++ b/modulefiles/tasks/gaea/make_grid.local
@@ -2,8 +2,6 @@
 module use -a /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
 module load miniconda3/4.8.3
 
-setenv PS1 "\u@\h:\w> "
-
 if [module-info mode load] {
   system "conda activate regional_workflow"
 }

--- a/modulefiles/tasks/gaea/make_ics.local
+++ b/modulefiles/tasks/gaea/make_ics.local
@@ -2,8 +2,6 @@
 module use -a /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
 module load miniconda3/4.8.3
 
-setenv PS1 "\u@\h:\w> "
-
 if [module-info mode load] {
   system "conda activate regional_workflow"
 }

--- a/modulefiles/tasks/gaea/make_lbcs.local
+++ b/modulefiles/tasks/gaea/make_lbcs.local
@@ -2,8 +2,6 @@
 module use -a /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
 module load miniconda3/4.8.3
 
-setenv PS1 "\u@\h:\w> "
-
 if [module-info mode load] {
   system "conda activate regional_workflow"
 }

--- a/modulefiles/tasks/gaea/run_fcst.local
+++ b/modulefiles/tasks/gaea/run_fcst.local
@@ -2,8 +2,6 @@
 module use -a /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
 module load miniconda3/4.8.3
 
-setenv PS1 "\u@\h:\w> "
-
 if [module-info mode load] {
   system "conda activate regional_workflow"
 }


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 

Remove setting PS1 from modulefiles/tasks/gaea/*.local

The miniconda3 `profile.sh` on gaea script was fixed as suggested by @mkavulich, and setting `PS1` in the task modulefiles is no longer required on gaea.

## TESTS CONDUCTED

See https://github.com/ufs-community/ufs-srweather-app/pull/101

## ASSOCIATED PRS

https://github.com/ufs-community/ufs-srweather-app/pull/101
