### PR TITLE
Remove the first instance of "RUN_CMD_FCST" in var_defns.sh to avoid potential undefined variable issues

### DIFF
--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -2539,6 +2539,15 @@ fi
 #
 #-----------------------------------------------------------------------
 #
+# Because RUN_CMD_FCST can include PE_MEMBER01 (and theoretically other
+# variables calculated in this script), delete the first occurance of it
+# in the var_defns file, and write it again at the end.
+#
+#-----------------------------------------------------------------------
+$SED -i '/^RUN_CMD_FCST=/d' $GLOBAL_VAR_DEFNS_FP
+#
+#-----------------------------------------------------------------------
+#
 # Continue appending variable defintions to the variable definitions 
 # file.
 #


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
It was found that if set -u is in the user's default bash environment, this will cause the launch script or individual run scripts to fail because you're using a variable before it's defined; this is likely to occur if you submit any of these scripts from a crontab. This was due to the way that the default run command was set up for MacOS and generic LINUX platforms, which was a bit of a hack that resulted in RUN_CMD_FCST being defined twice in var_defns.sh. The fix will delete the first instance of RUN_CMD_FCST in var_defns.sh so that it is no longer referencing an undefined variable early on.

This potential bug does not affect Tier 1 supported platforms, only MacOS and generic Linux.

## TESTS CONDUCTED: 
Tested on affected MacOS platform and the fix worked. Also ran end-to-end tests on Hera and Cheyenne (still running) as a sanity check.

## CONTRIBUTORS (optional): 
Thanks to @christinaholtNOAA for bringing this issue to light.
