### PR TITLE
Fixed an issue that colorlist is one element less than clevs in ush/P…

### DIFF
--- a/ush/Python/plot_allvars.py
+++ b/ush/Python/plot_allvars.py
@@ -9,7 +9,7 @@
 #           David Wright 	Org: University of Michigan
 #
 # Instructions:		Make sure all the necessary modules can be imported.
-#                       Five command line arguments are needed:
+#                       Six command line arguments are needed:
 #                       1. Cycle date/time in YYYYMMDDHH format
 #                       2. Starting forecast hour
 #                       3. Ending forecast hour
@@ -603,7 +603,7 @@ for fhr in fhours:
     units = 'J/kg'
     clevs = [100,250,500,1000,1500,2000,2500,3000,3500,4000,4500,5000]
     clevs2 = [-2000,-500,-250,-100,-25]
-    colorlist = ['blue','dodgerblue','cyan','mediumspringgreen','#FAFAD2','#EEEE00','#EEC900','darkorange','crimson','darkred']
+    colorlist = ['blue','dodgerblue','cyan','mediumspringgreen','#FAFAD2','#EEEE00','#EEC900','darkorange','crimson','darkred','black']
     cm = matplotlib.colors.ListedColormap(colorlist)
     norm = matplotlib.colors.BoundaryNorm(clevs, cm.N)
 


### PR DESCRIPTION
…ython/plot_allvars.py

## DESCRIPTION OF CHANGES: 
Add one color "black" to "colorlist" in file _ush/Python/plot_allvars.py_ about line 606.

## TESTS CONDUCTED: 

It is tested on Odin (NSSL Cray computer) using Python version 3.8.3, matplotlib-base 3.3.2  and cartopy  0.18.0.

## ISSUE (optional): 

-  “colorlist” is 2 elements less than “clevs”. It is not allowed. 
-  “colorlist” can only be 1 element less than “clevs”. 
- The error message from Python is
`ValueError: There are 11 color bins including extensions, but ncolors = 10; ncolors must equal or exceed the number of bins`


