### PR TITLE
Add 'module purge' to launch script for Orion

### DIFF
--- a/ush/launch_FV3LAM_wflow.sh
+++ b/ush/launch_FV3LAM_wflow.sh
@@ -113,6 +113,7 @@ if [ "$MACHINE" = "CHEYENNE" ]; then
   module use -a /glade/p/ral/jntp/UFS_SRW_app/modules/
   module load rocoto
 elif [ "$MACHINE" = "ORION" ]; then
+  module purge
   module load contrib rocoto
 elif [ "$MACHINE" = "WCOSS_DELL_P3" ]; then
   module purge


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 
The 'module purge' command is added to the launch script 'launch_FV3LAM_wflow.sh' to avoid a module conflict on Orion.

## TESTS CONDUCTED: 
The tasks are submitted without any conflicts on Orion.

## ISSUE: 
Fixes issue mentioned in #436 

