### PR TITLE
Update of gaea environment to not use lua modules

### DIFF
--- a/modulefiles/tasks/gaea/make_grid.local
+++ b/modulefiles/tasks/gaea/make_grid.local
@@ -1,7 +1,3 @@
 #%Module
-module use -a /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
-module load miniconda3/4.8.3
-
-if [module-info mode load] {
-  system "conda activate regional_workflow"
-}
+module use /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
+module load miniconda3/4.8.3-regional-workflow

--- a/modulefiles/tasks/gaea/make_ics.local
+++ b/modulefiles/tasks/gaea/make_ics.local
@@ -1,7 +1,3 @@
 #%Module
-module use -a /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
-module load miniconda3/4.8.3
-
-if [module-info mode load] {
-  system "conda activate regional_workflow"
-}
+module use /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
+module load miniconda3/4.8.3-regional-workflow

--- a/modulefiles/tasks/gaea/make_lbcs.local
+++ b/modulefiles/tasks/gaea/make_lbcs.local
@@ -1,7 +1,3 @@
 #%Module
-module use -a /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
-module load miniconda3/4.8.3
-
-if [module-info mode load] {
-  system "conda activate regional_workflow"
-}
+module use /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
+module load miniconda3/4.8.3-regional-workflow

--- a/modulefiles/tasks/gaea/run_fcst.local
+++ b/modulefiles/tasks/gaea/run_fcst.local
@@ -1,7 +1,3 @@
 #%Module
-module use -a /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
-module load miniconda3/4.8.3
-
-if [module-info mode load] {
-  system "conda activate regional_workflow"
-}
+module use /lustre/f2/pdata/esrl/gsd/contrib/modulefiles
+module load miniconda3/4.8.3-regional-workflow

--- a/ush/load_modules_run_task.sh
+++ b/ush/load_modules_run_task.sh
@@ -128,7 +128,7 @@ case "$MACHINE" in
     ;;
 #
   "GAEA")
-    . /lustre/f2/pdata/esrl/gsd/contrib/lua-5.1.4.9/init/init_lmod.sh
+    . /opt/modules/default/init/sh
     ;;
 #
   *)


### PR DESCRIPTION
# Description

Update gaea task module files and `ush/load_modules_run_task.sh` to avoid using the lua module environment.

See https://github.com/ufs-community/ufs-srweather-app/pull/107 for testing.

