### PR TITLE
Modify FIXgsm path for Gaea.

### DIFF
--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -753,7 +753,7 @@ case $MACHINE in
     ;;
 
   "GAEA")
-    FIXgsm=${FIXgsm:-"/lustre/f2/pdata/esrl/gsd/ufs/ufs-srw-release-v1.0.0/fix"}
+    FIXgsm=${FIXgsm:-"/lustre/f2/pdata/esrl/gsd/ufs/ufs-srw-release-v1.0.0/fix/fix_am"}
     TOPO_DIR=${TOPO_DIR:-"/lustre/f2/pdata/esrl/gsd/ufs/ufs-srw-release-v1.0.0/fix/fix_orog"}
     SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/lustre/f2/pdata/esrl/gsd/ufs/ufs-srw-release-v1.0.0/fix/sfc_climo"}
     ;;


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Update the FIXgsm (fix_am) directory for Gaea.

## TESTS CONDUCTED: 
Tested on Gaea with a 3-km domains using the RRFS_v1alpha SDF.

