### PR TITLE
Changed multiprocessing pool call to serial call to avoid issue on Ma…

### DIFF
--- a/ush/Python/plot_allvars.py
+++ b/ush/Python/plot_allvars.py
@@ -1,6 +1,6 @@
 ################################################################################
 ####  Python Script Documentation Block
-#                      
+#
 # Script name:       	plot_allvars.py
 # Script description:  	Generates plots from FV3-LAM post processed grib2 output
 #			over the CONUS
@@ -27,11 +27,11 @@
 #                          -More information regarding files needed to setup
 #                            display maps in Cartopy, see SRW App Users' Guide
 #
-#           		To create plots for forecast hours 20-24 from 5/7 00Z 
+#           		To create plots for forecast hours 20-24 from 5/7 00Z
 #                        cycle with hourly output:
 #                          python plot_allvars.py 2020050700 20 24 1 \
 #                          /path/to/expt_dirs/experiment/name \
-#                          /path/to/base/cartopy/maps 
+#                          /path/to/base/cartopy/maps
 #
 #                       The variable domains in this script can be set to either
 #                         'conus' for a CONUS map or 'regional' where the map
@@ -228,7 +228,7 @@ parser.add_argument("Forecast hour increment")
 parser.add_argument("Path to experiment directory")
 parser.add_argument("Path to base directory of cartopy shapefiles")
 args = parser.parse_args()
-              
+
 # Read date/time, forecast hour, and directory paths from command line
 ymdh = str(sys.argv[1])
 ymd = ymdh[0:8]
@@ -312,7 +312,7 @@ for fhr in fhours:
   print(Lon0)
 
 # Specify plotting domains
-# User can add domains here, just need to specify lat/lon information below 
+# User can add domains here, just need to specify lat/lon information below
 # (if dom == 'conus' block)
   domains=['conus']    # Other option is 'regional'
 
@@ -368,7 +368,7 @@ for fhr in fhours:
   qpf = data1.select(name='Total Precipitation',lengthOfTimeRange=fhr)[0].values * 0.0393701
 
 # Composite reflectivity
-  refc = data1.select(name='Maximum/Composite radar reflectivity')[0].values 
+  refc = data1.select(name='Maximum/Composite radar reflectivity')[0].values
 
   if (fhr > 0):
 # Max/Min Hourly 2-5 km Updraft Helicity
@@ -391,8 +391,13 @@ for fhr in fhours:
   def main():
 
   # Number of processes must coincide with the number of domains to plot
-    pool = multiprocessing.Pool(len(domains))
-    pool.map(plot_all,domains)
+    #pool = multiprocessing.Pool(len(domains))
+    #pool.map(plot_all,domains)
+
+    # To avoid import multiprocessing recursively on MacOS etc.
+    # Anyway since we only have one domain for SRW application
+    for dom in domains:
+        plot_all(dom)
 
   def plot_all(dom):
 
@@ -401,7 +406,7 @@ for fhr in fhours:
   # Map corners for each domain
     if dom == 'conus':
       llcrnrlon = -120.5
-      llcrnrlat = 21.0 
+      llcrnrlat = 21.0
       urcrnrlon = -64.5
       urcrnrlat = 49.0
       lat_0 = 35.4
@@ -421,7 +426,7 @@ for fhr in fhours:
     fig = plt.figure(figsize=(10,10))
     ax1 = fig.add_axes([0.1,0.1,0.8,0.8])
 
-  # Define where Cartopy Maps are located    
+  # Define where Cartopy Maps are located
     cartopy.config['data_dir'] = CARTOPY_DIR
 
     back_res='50m'
@@ -455,7 +460,7 @@ for fhr in fhours:
                       linewidth=fline_wd,alpha=falpha)
 
   # All lat lons are earth relative, so setup the associated projection correct for that data
-    transform = ccrs.PlateCarree() 
+    transform = ccrs.PlateCarree()
 
   # high-resolution background images
     if back_img=='on':
@@ -484,7 +489,7 @@ for fhr in fhours:
     cm = plt.cm.Spectral_r
     norm = matplotlib.colors.BoundaryNorm(clevs, cm.N)
 
-    cs1_a = plt.pcolormesh(lon_shift,lat_shift,slp,transform=transform,cmap=cm,norm=norm) 
+    cs1_a = plt.pcolormesh(lon_shift,lat_shift,slp,transform=transform,cmap=cm,norm=norm)
     cbar1 = plt.colorbar(cs1_a,orientation='horizontal',pad=0.05,shrink=0.6,extend='both')
     cbar1.set_label(units,fontsize=8)
     cbar1.ax.tick_params(labelsize=8)
@@ -583,7 +588,7 @@ for fhr in fhours:
     cbar1.ax.tick_params(labelsize=8)
     plt.barbs(lon_shift[::skip,::skip],lat_shift[::skip,::skip],uwind[::skip,::skip],vwind[::skip,::skip],length=barblength,linewidth=0.5,color='black',transform=transform)
     ax.text(.5,1.03,'FV3-LAM 10-m Winds ('+units+') \n initialized: '+itime+' valid: '+vtime + ' (f'+fhour+')',horizontalalignment='center',fontsize=8,transform=ax.transAxes,bbox=dict(facecolor='white',alpha=0.85,boxstyle='square,pad=0.2'))
-    
+
     compress_and_save(EXPT_DIR+'/'+ymdh+'/postprd/10mwind_'+dom+'_f'+fhour+'.png')
     t2 = time.perf_counter()
     t3 = round(t2-t1, 3)
@@ -706,7 +711,7 @@ for fhr in fhours:
       units = 'in'
       clevs = [0.01,0.1,0.25,0.5,0.75,1,1.25,1.5,1.75,2,2.5,3,4,5,7,10,15,20]
       clevsdif = [-3,-2.5,-2,-1.5,-1,-0.5,0,0.5,1,1.5,2,2.5,3]
-      colorlist = ['chartreuse','limegreen','green','blue','dodgerblue','deepskyblue','cyan','mediumpurple','mediumorchid','darkmagenta','darkred','crimson','orangered','darkorange','goldenrod','gold','yellow']  
+      colorlist = ['chartreuse','limegreen','green','blue','dodgerblue','deepskyblue','cyan','mediumpurple','mediumorchid','darkmagenta','darkred','crimson','orangered','darkorange','goldenrod','gold','yellow']
       cm = matplotlib.colors.ListedColormap(colorlist)
       norm = matplotlib.colors.BoundaryNorm(clevs, cm.N)
 
@@ -740,7 +745,7 @@ for fhr in fhours:
     colorlist = ['turquoise','dodgerblue','mediumblue','lime','limegreen','green','#EEEE00','#EEC900','darkorange','red','firebrick','darkred','fuchsia']
     cm = matplotlib.colors.ListedColormap(colorlist)
     norm = matplotlib.colors.BoundaryNorm(clevs, cm.N)
-  
+
     cs_1 = plt.pcolormesh(lon_shift,lat_shift,refc,transform=transform,cmap=cm,vmin=5,norm=norm)
     cs_1.cmap.set_under('white',alpha=0.)
     cs_1.cmap.set_over('black')
@@ -758,7 +763,7 @@ for fhr in fhours:
 #################################
   # Plot Max/Min Hourly 2-5 km UH
 #################################
-    if (fhr > 0):		# Do not make max/min hourly 2-5 km UH plot for forecast hour 0 	
+    if (fhr > 0):		# Do not make max/min hourly 2-5 km UH plot for forecast hour 0
       t1 = time.perf_counter()
       print(('Working on Max/Min Hourly 2-5 km UH for '+dom))
 

--- a/ush/Python/plot_allvars_diff.py
+++ b/ush/Python/plot_allvars_diff.py
@@ -1,8 +1,8 @@
 ################################################################################
 ####  Python Script Documentation Block
-#                      
+#
 # Script name:       	plot_allvars_diff.py
-# Script description:  	Generates difference plots from FV3-LAM post processed 
+# Script description:  	Generates difference plots from FV3-LAM post processed
 #                       grib2 output over the CONUS
 #
 # Authors:  Ben Blake		Org: NOAA/NWS/NCEP/EMC		Date: 2020-08-24
@@ -30,11 +30,11 @@
 #                          -More information regarding files needed to setup
 #                            display maps in Cartopy, see SRW App Users' Guide
 #
-#           		To create plots for forecast hours 20-24 from 5/7 00Z 
+#           		To create plots for forecast hours 20-24 from 5/7 00Z
 #                        cycle with hourly output:
-#                          python plot_allvars_diff.py 2020050700  20 24 1 \ 
+#                          python plot_allvars_diff.py 2020050700  20 24 1 \
 #                          /path/to/expt_dir_1 /path/to/expt_dir_2 \
-#                          /path/to/base/cartopy/maps 
+#                          /path/to/base/cartopy/maps
 #
 #                       The variable domains in this script can be set to either
 #                         'conus' for a CONUS map or 'regional' where the map
@@ -232,7 +232,7 @@ parser.add_argument("Path to experiment 1 directory")
 parser.add_argument("Path to experiment 2 directory")
 parser.add_argument("Path to base directory of cartopy shapefiles")
 args = parser.parse_args()
-              
+
 # Read date/time, forecast hour, and directory paths from command line
 ymdh = str(sys.argv[1])
 ymd = ymdh[0:8]
@@ -323,7 +323,7 @@ for fhr in fhours:
   print(Lon0)
 
 # Specify plotting domains
-# User can add domains here, just need to specify lat/lon information below 
+# User can add domains here, just need to specify lat/lon information below
 # (if dom == 'conus' block)
   domains=['conus']    # Other option is 'regional'
 
@@ -413,8 +413,8 @@ for fhr in fhours:
   qpf_diff = qpf_2 - qpf_1
 
 # Composite reflectivity
-  refc_1 = data1.select(name='Maximum/Composite radar reflectivity')[0].values 
-  refc_2 = data2.select(name='Maximum/Composite radar reflectivity')[0].values 
+  refc_1 = data1.select(name='Maximum/Composite radar reflectivity')[0].values
+  refc_2 = data2.select(name='Maximum/Composite radar reflectivity')[0].values
 
   if (fhr > 0):
 # Max/Min Hourly 2-5 km Updraft Helicity
@@ -442,9 +442,14 @@ for fhr in fhours:
 
   def main():
 
-  # Number of processes must coincide with the number of domains to plot
-    pool = multiprocessing.Pool(len(domains))
-    pool.map(plot_all,domains)
+    # Number of processes must coincide with the number of domains to plot
+    #pool = multiprocessing.Pool(len(domains))
+    #pool.map(plot_all,domains)
+
+    # To avoid import multiprocessing recursively on MacOS/Windows etc.
+    # Anyway since we only have one domain for SRW application
+    for dom in domains:
+        plot_all(dom)
 
   def plot_all(dom):
 
@@ -453,7 +458,7 @@ for fhr in fhours:
   # Map corners for each domain
     if dom == 'conus':
       llcrnrlon = -120.5
-      llcrnrlat = 21.0 
+      llcrnrlat = 21.0
       urcrnrlon = -64.5
       urcrnrlat = 49.0
       lat_0 = 35.4
@@ -473,7 +478,7 @@ for fhr in fhours:
     fig = plt.figure(figsize=(10,10))
     gs = GridSpec(9,9,wspace=0.0,hspace=0.0)
 
-  # Define where Cartopy Maps are located    
+  # Define where Cartopy Maps are located
     cartopy.config['data_dir'] = CARTOPY_DIR
 
     back_res='50m'
@@ -511,7 +516,7 @@ for fhr in fhours:
                       linewidth=fline_wd,alpha=falpha)
 
   # All lat lons are earth relative, so setup the associated projection correct for that data
-    transform = ccrs.PlateCarree() 
+    transform = ccrs.PlateCarree()
 
   # high-resolution background images
     if back_img=='on':
@@ -557,7 +562,7 @@ for fhr in fhours:
     norm = matplotlib.colors.BoundaryNorm(clevs, cm.N)
     normdiff = matplotlib.colors.BoundaryNorm(clevsdiff, cmdiff.N)
 
-    cs1_a = ax1.pcolormesh(lon_shift,lat_shift,slp_1,transform=transform,cmap=cm,norm=norm) 
+    cs1_a = ax1.pcolormesh(lon_shift,lat_shift,slp_1,transform=transform,cmap=cm,norm=norm)
     cbar1 = plt.colorbar(cs1_a,ax=ax1,orientation='horizontal',pad=0.05,shrink=0.6,extend='both')
     cbar1.set_label(units,fontsize=6)
     cbar1.ax.tick_params(labelsize=5)
@@ -565,7 +570,7 @@ for fhr in fhours:
     plt.clabel(cs1_b,np.arange(940,1060,4),inline=1,fmt='%d',fontsize=6)
     ax1.text(.5,1.03,'FV3-LAM SLP ('+units+') \n initialized: '+itime+' valid: '+vtime + ' (f'+fhour+')',horizontalalignment='center',fontsize=8,transform=ax1.transAxes,bbox=dict(facecolor='white',alpha=0.85,boxstyle='square,pad=0.2'))
 
-    cs2_a = ax2.pcolormesh(lon2_shift,lat2_shift,slp_2,transform=transform,cmap=cm,norm=norm) 
+    cs2_a = ax2.pcolormesh(lon2_shift,lat2_shift,slp_2,transform=transform,cmap=cm,norm=norm)
     cbar2 = plt.colorbar(cs2_a,ax=ax2,orientation='horizontal',pad=0.05,shrink=0.6,extend='both')
     cbar2.set_label(units,fontsize=6)
     cbar2.ax.tick_params(labelsize=5)
@@ -738,7 +743,7 @@ for fhr in fhours:
     cbar3.set_label(units,fontsize=6)
     cbar3.ax.tick_params(labelsize=6)
     ax3.text(.5,1.03,'FV3-LAM-2 - FV3-LAM 10-m Winds ('+units+') \n initialized: '+itime+' valid: '+vtime+' (f'+fhour+')',horizontalalignment='center',fontsize=6,transform=ax3.transAxes,bbox=dict(facecolor='white',alpha=0.85,boxstyle='square,pad=0.2'))
-   
+
     compress_and_save(EXPT_DIR_1+'/'+ymdh+'/postprd/10mwind_diff_'+dom+'_f'+fhour+'.png')
     t2 = time.perf_counter()
     t3 = round(t2-t1, 3)
@@ -816,7 +821,7 @@ for fhr in fhours:
 
     units = 'x10${^5}$ s${^{-1}}$'
     skip = round(177.28*(dx/1000.)**-.97)
-    print('skipping every '+str(skip)+' grid points to plot')  
+    print('skipping every '+str(skip)+' grid points to plot')
     barblength = 4
 
     vortlevs = [16,20,24,28,32,36,40]
@@ -878,7 +883,7 @@ for fhr in fhours:
 
     units = 'kts'
     skip = round(177.28*(dx/1000.)**-.97)
-    print('skipping every '+str(skip)+' grid points to plot')  
+    print('skipping every '+str(skip)+' grid points to plot')
     barblength = 4
 
     clevs = [50,60,70,80,90,100,110,120,130,140,150]
@@ -938,7 +943,7 @@ for fhr in fhours:
       units = 'in'
       clevs = [0.01,0.1,0.25,0.5,0.75,1,1.25,1.5,1.75,2,2.5,3,4,5,7,10,15,20]
       clevsdiff = [-3,-2.5,-2,-1.5,-1,-0.5,0,0.5,1,1.5,2,2.5,3]
-      colorlist = ['chartreuse','limegreen','green','blue','dodgerblue','deepskyblue','cyan','mediumpurple','mediumorchid','darkmagenta','darkred','crimson','orangered','darkorange','goldenrod','gold','yellow']  
+      colorlist = ['chartreuse','limegreen','green','blue','dodgerblue','deepskyblue','cyan','mediumpurple','mediumorchid','darkmagenta','darkred','crimson','orangered','darkorange','goldenrod','gold','yellow']
       cm = matplotlib.colors.ListedColormap(colorlist)
       norm = matplotlib.colors.BoundaryNorm(clevs, cm.N)
       normdiff = matplotlib.colors.BoundaryNorm(clevsdiff, cmdiff.N)
@@ -978,7 +983,7 @@ for fhr in fhours:
 #################################
   # Plot Max/Min Hourly 2-5 km UH
 #################################
-# Do not make max/min hourly 2-5 km UH plot for forecast hour 0 	
+# Do not make max/min hourly 2-5 km UH plot for forecast hour 0
       t1 = time.perf_counter()
       print(('Working on Max/Min Hourly 2-5 km UH for '+dom))
 
@@ -1050,7 +1055,7 @@ for fhr in fhours:
     colorlist = ['turquoise','dodgerblue','mediumblue','lime','limegreen','green','#EEEE00','#EEC900','darkorange','red','firebrick','darkred','fuchsia']
     cm = matplotlib.colors.ListedColormap(colorlist)
     norm = matplotlib.colors.BoundaryNorm(clevs, cm.N)
-  
+
     cs_1 = ax1.pcolormesh(lon_shift,lat_shift,refc_1,transform=transform,cmap=cm,vmin=5,norm=norm)
     cs_1.cmap.set_under('white',alpha=0.)
     cs_1.cmap.set_over('black')


### PR DESCRIPTION
…cOS/Windows

## DESCRIPTION OF CHANGES: 
To eliminate the multiprocessing pool call in the python plotting scripts and change them to serial calls since we have only one domain in the SRW Application

## TESTS CONDUCTED: 
Tests have been performed on Odin and a MacOS machine.

## ISSUE (optional): 
The original multiprocessing call will cause this error message on MacOS,
```
An attempt has been made to start a new process before the
        current process has finished its bootstrapping phase.
        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:
            if __name__ == '__main__':
                freeze_support()
                ...
        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
```
It is because on Windows or MacOS the subprocesses will import (i.e. execute) the main module at start, which creates subprocesses recursively. It can be avoided by inserting an if __name__ == '__main__': guard in the main module. However, this python script was written mainly as a running script (the same style as Bash etc.) and it is not easy to wrap them in a main function.
The easy fix is just to eliminate the use of multiprocessing. Anyway, we only have one domain for SRW Application right now.

## Notes:

The changes are mainly in the `main` function of _plot_allvars.py_ & _plot_allvars_diff.py_. All other changes are just the removing of extra blank spaces at end of all code lines (a feature of my editor and a code convention I believe we should adapt for code development).

## CONTRIBUTORS (optional): 
It has been discussed during the testing meeting with @BenjaminBlake-NOAA, @climbfuji and @JeffBeck-NOAA  etc.

