### PR TITLE
Use mpirun instead of srun on Jet to avoid jobs freezing when starting MPI programs.

### DIFF
--- a/scripts/exregional_make_ics.sh
+++ b/scripts/exregional_make_ics.sh
@@ -100,7 +100,8 @@ case "$MACHINE" in
 
   "JET")
     ulimit -s unlimited
-    APRUN="srun"
+    nprocs=$(( NNODES_MAKE_ICS*PPN_MAKE_ICS ))
+    APRUN="mpirun -np $nprocs"
     ;;
 
   "GAEA")

--- a/scripts/exregional_make_lbcs.sh
+++ b/scripts/exregional_make_lbcs.sh
@@ -100,7 +100,8 @@ case "$MACHINE" in
 
   "JET")
     ulimit -s unlimited
-    APRUN="srun"
+    nprocs=$(( NNODES_MAKE_LBCS*PPN_MAKE_LBCS ))
+    APRUN="mpirun -np $nprocs"
     ;;
 
   "GAEA")

--- a/scripts/exregional_make_sfc_climo.sh
+++ b/scripts/exregional_make_sfc_climo.sh
@@ -152,7 +152,8 @@ case $MACHINE in
     ;;
 
   "JET")
-    APRUN="srun"
+    nprocs=$(( NNODES_MAKE_SFC_CLIMO*PPN_MAKE_SFC_CLIMO ))
+    APRUN="mpirun -np $nprocs"
     ;;
 
   "GAEA")

--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -122,7 +122,8 @@ case $MACHINE in
   "JET")
     ulimit -s unlimited
     ulimit -a
-    APRUN="srun"
+    nprocs=$(( NNODES_RUN_FCST*PPN_RUN_FCST ))
+    APRUN="mpirun -np $nprocs"
     OMP_NUM_THREADS=4
     ;;
 

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -117,7 +117,8 @@ case $MACHINE in
     ;;
 
   "JET")
-    APRUN="srun"
+    nprocs=$(( NNODES_RUN_POST*PPN_RUN_POST ))
+    APRUN="mpirun -np $nprocs"
     ;;
 
   "GAEA")


### PR DESCRIPTION
The scripts are using the wrong MPI launcher on Jet.

On Jet, some MPI programs will freeze forever if run within srun (especially with large jobs) which is why the admins suggest mpirun. This happened for me when running the workflow on Jet. Nobody has tracked down the cause of this Jet SLURM bug, so it might depend on the user account; I can't know. However, it is 100% reproducible for the same job in the same account. The global workflow, and parts of the RAPX and HRRRX workflow, use mpirun; so does JET.env. The regional_workflow should follow the admin recommendations too, so the workflow will run in all accounts with all job sizes.

All jobs will use "APRUN=mpirun...", copied from the "CHEYENNE" block. For the sfc_climo job, it looks like this:

```
  "JET")
    nprocs=$(( NNODES_MAKE_SFC_CLIMO*PPN_MAKE_SFC_CLIMO ))
    APRUN="mpirun -np $nprocs"
    ;;
```

instead of:

```
  "JET")
    APRUN="srun"
    ;;
```