### PR TITLE
Fix the 'fdiag' issue on the develop branch

### DIFF
--- a/ush/templates/FV3.input.yml
+++ b/ush/templates/FV3.input.yml
@@ -44,7 +44,7 @@ FV3_RRFS_v1alpha:
     lsm: 2
     lsoil_lsm: 4
   atmos_model_nml:
-    fdiag: 3
+    fdiag: 1
 
 FV3_RRFS_v1beta:
   gfs_physics_nml:
@@ -57,7 +57,7 @@ FV3_RRFS_v1beta:
     lsm: 2
     lsoil_lsm: 4
   atmos_model_nml:
-    fdiag: 3
+    fdiag: 1
 
 FV3_HRRR:
   fv_core_nml:
@@ -221,7 +221,7 @@ FV3_GFS_2017_gfdlmp_regional:
 FV3_GFS_v15p2:
   atmos_model_nml:
     ccpp_suite: FV3_GFS_v15
-    fdiag: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 18, 21, 24]
+    fdiag: 1
   fms_nml:
     domains_stack_size: 1800200
   fv_core_nml: &gfs_v15_fv_core
@@ -312,7 +312,7 @@ FV3_GFS_v15p2:
 FV3_GFS_v16beta:
   atmos_model_nml:
     ccpp_suite: FV3_GFS_v16
-    fdiag: 3
+    fdiag: 1
     fhmax: 240
     fhmaxhf: 0
     fhout: 3
@@ -386,7 +386,7 @@ FV3_GFS_v16beta:
 FV3_CPT_v0:
   atmos_model_nml:
     ccpp_suite: FV3_CPT_v0
-    fdiag: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 15, 18, 21, 24]
+    fdiag: 1
   fms_nml:
     domains_stack_size: 1800200
   fv_core_nml:

--- a/ush/templates/FV3.input.yml
+++ b/ush/templates/FV3.input.yml
@@ -43,8 +43,6 @@ FV3_RRFS_v1alpha:
     imfshalcnv: -1
     lsm: 2
     lsoil_lsm: 4
-  atmos_model_nml:
-    fdiag: 1
 
 FV3_RRFS_v1beta:
   gfs_physics_nml:
@@ -56,8 +54,6 @@ FV3_RRFS_v1beta:
     imfshalcnv: -1
     lsm: 2
     lsoil_lsm: 4
-  atmos_model_nml:
-    fdiag: 1
 
 FV3_HRRR:
   fv_core_nml:
@@ -221,7 +217,6 @@ FV3_GFS_2017_gfdlmp_regional:
 FV3_GFS_v15p2:
   atmos_model_nml:
     ccpp_suite: FV3_GFS_v15
-    fdiag: 1
   fms_nml:
     domains_stack_size: 1800200
   fv_core_nml: &gfs_v15_fv_core
@@ -312,7 +307,6 @@ FV3_GFS_v15p2:
 FV3_GFS_v16beta:
   atmos_model_nml:
     ccpp_suite: FV3_GFS_v16
-    fdiag: 1
     fhmax: 240
     fhmaxhf: 0
     fhout: 3
@@ -386,7 +380,6 @@ FV3_GFS_v16beta:
 FV3_CPT_v0:
   atmos_model_nml:
     ccpp_suite: FV3_CPT_v0
-    fdiag: 1
   fms_nml:
     domains_stack_size: 1800200
   fv_core_nml:


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
As described in PR https://github.com/NOAA-EMC/regional_workflow/pull/451 for the release branch, all the `fdiag' entries are removed from 'ush/templates/FV3.input.yml' on the develop branch.


## TESTS CONDUCTED: 
Graduate Student Test (CONUS 25km, FV3_GFS_v15p2):
- Before: **step** shape (every three in a row) in 12-24hr, and constant after 24hr
![fv3lam_out_grb2his_hera_old](https://user-images.githubusercontent.com/60152248/110733507-13da2980-81f4-11eb-8dd5-cf7122b07f6e.png)

- After: smooth curve (no same values over the period)
![fv3lam_out_grb2his_hera](https://user-images.githubusercontent.com/60152248/110733785-92cf6200-81f4-11eb-931e-66fbf7a49846.png)


## ISSUE: 
- Fixes issue mentioned in #453.
- Related to PR https://github.com/NOAA-EMC/regional_workflow/pull/451
