### PR TITLE
Export OMP settings in the make_orog ex-script and change the default…

### DIFF
--- a/scripts/exregional_make_ics.sh
+++ b/scripts/exregional_make_ics.sh
@@ -76,9 +76,9 @@ print_input_args valid_args
 #
 #-----------------------------------------------------------------------
 #
-KMP_AFFINITY=${KMP_AFFINITY_MAKE_ICS}
-OMP_NUM_THREADS=${OMP_NUM_THREADS_MAKE_ICS}
-OMP_STACKSIZE=${OMP_STACKSIZE_MAKE_ICS}
+export KMP_AFFINITY=${KMP_AFFINITY_MAKE_ICS}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS_MAKE_ICS}
+export OMP_STACKSIZE=${OMP_STACKSIZE_MAKE_ICS}
 #
 #-----------------------------------------------------------------------
 #

--- a/scripts/exregional_make_lbcs.sh
+++ b/scripts/exregional_make_lbcs.sh
@@ -76,9 +76,9 @@ print_input_args valid_args
 #
 #-----------------------------------------------------------------------
 #
-KMP_AFFINITY=${KMP_AFFINITY_MAKE_LBCS}
-OMP_NUM_THREADS=${OMP_NUM_THREADS_MAKE_LBCS}
-OMP_STACKSIZE=${OMP_STACKSIZE_MAKE_LBCS}
+export KMP_AFFINITY=${KMP_AFFINITY_MAKE_LBCS}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS_MAKE_LBCS}
+export OMP_STACKSIZE=${OMP_STACKSIZE_MAKE_LBCS}
 #
 #-----------------------------------------------------------------------
 #

--- a/scripts/exregional_make_orog.sh
+++ b/scripts/exregional_make_orog.sh
@@ -81,9 +81,9 @@ print_input_args valid_args
 #
 #-----------------------------------------------------------------------
 #
-KMP_AFFINITY=${KMP_AFFINITY_MAKE_OROG}
-OMP_NUM_THREADS=${OMP_NUM_THREADS_MAKE_OROG}
-OMP_STACKSIZE=${OMP_STACKSIZE_MAKE_OROG}
+export KMP_AFFINITY=${KMP_AFFINITY_MAKE_OROG}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS_MAKE_OROG}
+export OMP_STACKSIZE=${OMP_STACKSIZE_MAKE_OROG}
 #
 #-----------------------------------------------------------------------
 #

--- a/scripts/exregional_make_sfc_climo.sh
+++ b/scripts/exregional_make_sfc_climo.sh
@@ -82,9 +82,9 @@ print_input_args valid_args
 #
 #-----------------------------------------------------------------------
 #
-KMP_AFFINITY=${KMP_AFFINITY_MAKE_SFC_CLIMO}
-OMP_NUM_THREADS=${OMP_NUM_THREADS_MAKE_SFC_CLIMO}
-OMP_STACKSIZE=${OMP_STACKSIZE_MAKE_SFC_CLIMO}
+export KMP_AFFINITY=${KMP_AFFINITY_MAKE_SFC_CLIMO}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS_MAKE_SFC_CLIMO}
+export OMP_STACKSIZE=${OMP_STACKSIZE_MAKE_SFC_CLIMO}
 #
 #-----------------------------------------------------------------------
 #

--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -87,9 +87,9 @@ print_input_args valid_args
 #
 #-----------------------------------------------------------------------
 #
-KMP_AFFINITY=${KMP_AFFINITY_RUN_FCST}
-OMP_NUM_THREADS=${OMP_NUM_THREADS_RUN_FCST}
-OMP_STACKSIZE=${OMP_STACKSIZE_RUN_FCST}
+export KMP_AFFINITY=${KMP_AFFINITY_RUN_FCST}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS_RUN_FCST}
+export OMP_STACKSIZE=${OMP_STACKSIZE_RUN_FCST}
 #
 #-----------------------------------------------------------------------
 #

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -82,9 +82,9 @@ print_input_args valid_args
 #
 #-----------------------------------------------------------------------
 #
-KMP_AFFINITY=${KMP_AFFINITY_RUN_POST}
-OMP_NUM_THREADS=${OMP_NUM_THREADS_RUN_POST}
-OMP_STACKSIZE=${OMP_STACKSIZE_RUN_POST}
+export KMP_AFFINITY=${KMP_AFFINITY_RUN_POST}
+export OMP_NUM_THREADS=${OMP_NUM_THREADS_RUN_POST}
+export OMP_STACKSIZE=${OMP_STACKSIZE_RUN_POST}
 #
 #-----------------------------------------------------------------------
 #

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -1615,7 +1615,7 @@ GWD_HRRRsuite_BASEDIR=""
 #
 #-----------------------------------------------------------------------
 #
-KMP_AFFINITY_MAKE_OROG="scatter"
+KMP_AFFINITY_MAKE_OROG="disabled"
 OMP_NUM_THREADS_MAKE_OROG="6"
 OMP_STACKSIZE_MAKE_OROG="2048m"
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The make_orog task executables (at least for raw orog generation) require an "export" command for the OMP settings to be properly applied.  Also, changed the default KMP_AFFINITY value to match that used on WCOSS.

## TESTS CONDUCTED: 
Tested on Hera.

## CONTRIBUTORS (optional): 
@chan-hoo

