### PR TITLE
Fix path to staged data for WE2E tests on Cheyenne

### DIFF
--- a/tests/run_experiments.sh
+++ b/tests/run_experiments.sh
@@ -749,7 +749,7 @@ PTMP=\"${PTMP}\""
     elif [ "$MACHINE" = "JET" ]; then
       extrn_mdl_source_basedir="/mnt/lfs1/BMC/fim/Gerard.Ketefian/UFS_CAM/staged_extrn_mdl_files"
     elif [ "$MACHINE" = "CHEYENNE" ]; then
-      extrn_mdl_source_basedir="/glade/p/ral/jntp/UFS_CAM/staged_extrn_mdl_files"
+      extrn_mdl_source_basedir="/glade/p/ral/jntp/UFS_SRW_app/staged_extrn_mdl_files"
     elif [ "$MACHINE" = "ORION" ]; then
       extrn_mdl_source_basedir="/work/noaa/gsd-fv3-dev/gsketefia/UFS/staged_extrn_mdl_files"
     else


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Path to staged data for the Cheyenne end-to-end tests was incorrect.

## TESTS CONDUCTED: 
Subset of WE2E tests run on Cheyenne and all succeeded:
GST_release_public_v1
grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2

## DOCUMENTATION:
No changes necessary

## ISSUE (optional): 
Fixes issue mentioned in #464

## CONTRIBUTORS (optional): 
@jwolff-ncar 

