### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+# Description
+
+Provide a clear and concise description of the bug and what behavior you are expecting.
+
+## Steps to Reproduce
+
+Please provide detailed steps for reproducing the issue.
+
+1. step 1
+2. step 2
+3. see the bug...
+
+## Additional Context
+
+Please provide any relevant information about your setup. This is important in case the issue is not reproducible except for under certain conditions.
+
+* Machine
+* Compiler
+* Reference other issues or PRs in other repositories that this is related to, and how they are related.
+
+## Output
+
+Please include any relevant log files, screenshots or other output here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+## Description
+Provide a clear and concise description of the problem to be solved.
+
+## Solution
+Add a clear and concise description of the proposed solution.
+
+## Alternatives (optional)
+If applicable, add a description of any alternative solutions or features you've considered.
+
+## Related to (optional)
+Directly reference any issues or PRs in this or other repositories that this is related to, and describe how they are related.

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -16,6 +16,10 @@ One or more paragraphs describing the problem, solution, and required changes.
 ## TESTS CONDUCTED: 
 Explicitly state what tests were run on these changes, or if any are still pending (for README or other text-only changes, just put "None required". Make note of the compilers used, the platform/machine, and other relevant details as necessary. For more complicated changes, or those resulting in scientific changes, please be explicit!
 
+## DEPENDENCIES:
+Add any links to external PRs. For example:
+- ufs-community/ufs-srweather-app/pull/<pr_number>
+
 ## DOCUMENTATION:
 If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files in the ufs-srweather-app repository (docs/UsersGuide/source) as supporting material.
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
* Add dependencies section to existing PR template
* Add templates for bug and feature issues
* This will provide better guidance for developers on what information to provide when submitting an issue or PR, and allow better organization/prioritization of PRs and issues for code management.
* See: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates

## TESTS CONDUCTED: 
None required
## DOCUMENTATION:
None required
