### PR TITLE
Add new FIX files for recent update on Thompson scheme

### DIFF
--- a/ush/set_thompson_mp_fix_files.sh
+++ b/ush/set_thompson_mp_fix_files.sh
@@ -130,6 +130,8 @@ string."
       "freezeH2O.dat" \
       "qr_acr_qg.dat" \
       "qr_acr_qs.dat" \
+      "qr_acr_qgV2.dat" \
+      "qr_acr_qsV2.dat" \
       )
 
     if [ "${EXTRN_MDL_NAME_ICS}" != "HRRR" -a "${EXTRN_MDL_NAME_ICS}" != "RAP" ] || \


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- A recent update on Thompson scheme requires additional FIX files: `qr_acr_qgV2.dat` and `qr_arc_qsV2.dat`.
- The two files are added to the list of `thompson_mp_fix_files` in `ush/set_thompson_mp_fix_files.sh`.
- The two files have been added to the the `FIXgsm` directory on Hera, WCOSS dell and cray, Orion, Jet, and RZDM.

## TESTS CONDUCTED: 
- It was confirmed that the new two files were copied to the `fix_am` directory by running `generate_FV3LAM_wflow.sh`.

## ISSUE: 
- Fixes issue mentioned in #497 

## CONTRIBUTORS: 
@JiliDong-NOAA, @KateFriedman-NOAA 

