### PR TITLE
Parameterize name of forecast model in ush/setup.sh

### DIFF
--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -295,6 +295,9 @@ DOT_OR_USCORE="_"
 # the directory in which it is created in the build step to the executables
 # directory (EXECDIR; this is set during experiment generation).
 #
+# FCST_MODEL:
+# Name of forecast model (default=ufs_weather_model)
+#
 # WFLOW_XML_FN:
 # Name of the rocoto workflow XML file that the experiment generation
 # script creates and that defines the workflow for the experiment.
@@ -345,6 +348,8 @@ FV3_NML_BASE_ENS_FN="input.nml.base_ens"
 MODEL_CONFIG_FN="model_configure"
 NEMS_CONFIG_FN="nems.configure"
 FV3_EXEC_FN="ufs_model"
+
+FCST_MODEL="ufs_weather_model"
 
 WFLOW_XML_FN="FV3LAM_wflow.xml"
 GLOBAL_VAR_DEFNS_FN="var_defns.sh"

--- a/ush/launch_FV3LAM_wflow.sh
+++ b/ush/launch_FV3LAM_wflow.sh
@@ -101,12 +101,12 @@ elif [ "$MACHINE" = "WCOSS_DELL_P3" ]; then
   module purge
   module load lsf/10.1
   module use /gpfs/dell3/usrx/local/dev/emc_rocoto/modulefiles/
-  module load ruby/2.5.1 rocoto/1.2.4
+  module load ruby/2.5.1 rocoto/1.3.0rc2
 elif [ "$MACHINE" = "WCOSS_CRAY" ]; then
   module purge
   module load xt-lsfhpc/9.1.3
   module use -a /usrx/local/emc_rocoto/modulefiles
-  module load rocoto/1.2.4
+  module load rocoto/1.3.0rc2
 else
   module purge
   module load rocoto

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -845,7 +845,7 @@ property_name="local_path"
 #
 # Get the base directory of the FV3 forecast model code.
 #
-external_name="ufs_weather_model"
+external_name="${FCST_MODEL}"
 UFS_WTHR_MDL_DIR=$( \
 get_manage_externals_config_property \
 "${mng_extrns_cfg_fn}" "${external_name}" "${property_name}" ) || \


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- The name of the base directory of the external source code for the forecast model is parameterized in 'ush/setup.sh'.
- Its default value is 'ufs_weather_model' in 'ush/config_defaults.sh' and it can be specified in 'ush/config.sh'.
- Update the version of Rocoto for the WCOSS dell and cary.

## TESTS CONDUCTED: 
WE2E Tests on Hera:
- grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_NA_13km
- grid_RRFS_NA_3km

## ISSUE: 
Fixes issue mentioned in #503 
