### PR TITLE
Make the name of the forecast model the same as its repository

### DIFF
--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -296,7 +296,7 @@ DOT_OR_USCORE="_"
 # directory (EXECDIR; this is set during experiment generation).
 #
 # FCST_MODEL:
-# Name of forecast model (default=ufs_weather_model)
+# Name of forecast model (default=ufs-weather-model)
 #
 # WFLOW_XML_FN:
 # Name of the rocoto workflow XML file that the experiment generation

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -349,7 +349,7 @@ MODEL_CONFIG_FN="model_configure"
 NEMS_CONFIG_FN="nems.configure"
 FV3_EXEC_FN="ufs_model"
 
-FCST_MODEL="ufs_weather_model"
+FCST_MODEL="ufs-weather-model"
 
 WFLOW_XML_FN="FV3LAM_wflow.xml"
 GLOBAL_VAR_DEFNS_FN="var_defns.sh"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Change the underscores in the name of the ufs weather model (ufs_weather_model) to dashes (ufs-weather-model) in 'config_default.sh' to match it with the name of the authoritative repository.

## TESTS CONDUCTED: 
- GST test on the WCOSS dell

## DEPENDENCIES:
- https://github.com/ufs-community/ufs-srweather-app/pull/146

## ISSUE: 
- Fixes issue mentioned in #505 
- Related to https://github.com/ufs-community/ufs-srweather-app/issues/145
