### PR TITLE
Add a flag turning on/off the 'run_post' task in the workflow template

### DIFF
--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -1125,6 +1125,9 @@ VERBOSE="TRUE"
 #
 # SFC_CLIMO_DIR:
 # Same as GRID_DIR but for the surface climatology generation task.
+#
+# RUN_TASK_RUN_POST:
+# Flag that determines whether the run_post task is to be run
 # 
 # RUN_TASK_VX_GRIDSTAT:
 # Flag that determines whether the grid-stat verification task is to be
@@ -1144,6 +1147,8 @@ OROG_DIR="/path/to/pregenerated/orog/files"
 
 RUN_TASK_MAKE_SFC_CLIMO="TRUE"
 SFC_CLIMO_DIR="/path/to/pregenerated/surface/climo/files"
+
+RUN_TASK_RUN_POST="TRUE"
 
 RUN_TASK_GET_OBS_CCPA="FALSE"
 

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -284,6 +284,7 @@ settings="\
   'run_task_make_grid': ${RUN_TASK_MAKE_GRID}
   'run_task_make_orog': ${RUN_TASK_MAKE_OROG}
   'run_task_make_sfc_climo': ${RUN_TASK_MAKE_SFC_CLIMO}
+  'run_task_run_post': ${RUN_TASK_RUN_POST}
   'run_task_get_obs_ccpa': ${RUN_TASK_GET_OBS_CCPA}
   'run_task_get_obs_mrms': ${RUN_TASK_GET_OBS_MRMS}
   'run_task_get_obs_ndas': ${RUN_TASK_GET_OBS_NDAS}

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -232,6 +232,27 @@ fi
 #
 #-----------------------------------------------------------------------
 #
+# Make sure that RUN_TASK_RUN_POST is set to a valid value.
+#
+#-----------------------------------------------------------------------
+#
+check_var_valid_value \
+  "RUN_TASK_RUN_POST" "valid_vals_RUN_TASK_RUN_POST"
+#
+# Set RUN_TASK_RUN_POST to either "TRUE" or "FALSE" so we don't
+# have to consider other valid values later on.
+#
+RUN_TASK_RUN_POST=${RUN_TASK_RUN_POST^^}
+if [ "${RUN_TASK_RUN_POST}" = "TRUE" ] || \
+   [ "${RUN_TASK_RUN_POST}" = "YES" ]; then
+  RUN_TASK_RUN_POST="TRUE"
+elif [ "${RUN_TASK_RUN_POST}" = "FALSE" ] || \
+     [ "${RUN_TASK_RUN_POST}" = "NO" ]; then
+  RUN_TASK_RUN_POST="FALSE"
+fi
+#
+#-----------------------------------------------------------------------
+#
 # Make sure that RUN_TASK_VX_GRIDSTAT is set to a valid value.
 #
 #-----------------------------------------------------------------------
@@ -1838,21 +1859,6 @@ fi
 #
 . ./set_extrn_mdl_params.sh
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 #
 #-----------------------------------------------------------------------
 #
@@ -1961,7 +1967,6 @@ fi
 #-----------------------------------------------------------------------
 #
 mkdir_vrfy -p "$EXPTDIR"
-
 
 #
 #-----------------------------------------------------------------------
@@ -2077,11 +2082,6 @@ CRES=""
 if [ "${RUN_TASK_MAKE_GRID}" = "FALSE" ]; then
   CRES="C${RES_IN_FIXLAM_FILENAMES}"
 fi
-
-
-
-
-
 #
 #-----------------------------------------------------------------------
 #

--- a/ush/templates/FV3LAM_wflow.xml
+++ b/ush/templates/FV3LAM_wflow.xml
@@ -149,7 +149,7 @@ J-job then uses exec to run the J-job (while also terminating the LOAD_-
 MODULES_RUN_TASK_FP script.
 -->
 
-{% if run_task_make_grid %}
+{%- if run_task_make_grid %}
 <!--
 ************************************************************************
 ************************************************************************
@@ -171,9 +171,8 @@ MODULES_RUN_TASK_FP script.
     <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
 
   </task>
-{% endif %}
-
-{% if run_task_make_orog %}
+{%- endif %}
+{%- if run_task_make_orog %}
 <!--
 ************************************************************************
 ************************************************************************
@@ -203,9 +202,8 @@ MODULES_RUN_TASK_FP script.
     </dependency>
 
   </task>
-{% endif %}
-
-{% if run_task_make_sfc_climo %}
+{%- endif %}
+{%- if run_task_make_sfc_climo %}
 <!--
 ************************************************************************
 ************************************************************************
@@ -238,8 +236,7 @@ MODULES_RUN_TASK_FP script.
     </dependency>
 
   </task>
-{% endif %}
-
+{%- endif %}
 <!--
 ************************************************************************
 ************************************************************************
@@ -428,6 +425,7 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
+{%- if run_task_run_post %}
   {%- if sub_hourly_post %}
 <!--
 Define the post-processing task for first model output time.  The forecast 
@@ -611,7 +609,7 @@ always zero).
     {%- endif %}
   </metatask>
 
-{%- if sub_hourly_post %}
+  {%- if sub_hourly_post %}
 <!--
 Define the post-processing task for the last model output time.  The 
 forecast hour corresponding to this output time is the length of the 
@@ -660,6 +658,7 @@ the <task> tag to be identical to the ones above for other output times.
     </task>
 
   </metatask>
+  {%- endif %}
 {%- endif %}
 
 {%- if run_task_get_obs_ccpa %}

--- a/ush/valid_param_vals.sh
+++ b/ush/valid_param_vals.sh
@@ -47,6 +47,7 @@ valid_vals_WRTCMP_output_grid=("rotated_latlon" "lambert_conformal" "regional_la
 valid_vals_RUN_TASK_MAKE_GRID=("TRUE" "true" "YES" "yes" "FALSE" "false" "NO" "no")
 valid_vals_RUN_TASK_MAKE_OROG=("TRUE" "true" "YES" "yes" "FALSE" "false" "NO" "no")
 valid_vals_RUN_TASK_MAKE_SFC_CLIMO=("TRUE" "true" "YES" "yes" "FALSE" "false" "NO" "no")
+valid_vals_RUN_TASK_RUN_POST=("TRUE" "true" "YES" "yes" "FALSE" "false" "NO" "no")
 valid_vals_RUN_TASK_VX_GRIDSTAT=("TRUE" "true" "YES" "yes" "FALSE" "false" "NO" "no")
 valid_vals_RUN_TASK_VX_POINTSTAT=("TRUE" "true" "YES" "yes" "FALSE" "false" "NO" "no")
 valid_vals_QUILTING=("TRUE" "true" "YES" "yes" "FALSE" "false" "NO" "no")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Since the latest version of the ufs weather model has the in-line post option ('write_dopost' in model_configure), a flag turning on/off the 'run_post' task is added to the workflow template.

## TESTS CONDUCTED: 
GST test for 6h forecast on the wcoss dell

## ISSUE: 
Fixes issue mentioned in #509 
