### PR TITLE
Fix the array index issue on cycle_staus in the launch script

### DIFF
--- a/ush/launch_FV3LAM_wflow.sh
+++ b/ush/launch_FV3LAM_wflow.sh
@@ -316,7 +316,7 @@ done <<< "${rocotostat_output}"
 num_cycles_total=${#cycle_str[@]}
 num_cycles_completed=0
 for (( i=0; i<=$((num_cycles_total-1)); i++ )); do
-  if [ "${cycle_status}" = "Done" ]; then
+  if [ "${cycle_status[i]}" = "Done" ]; then
     num_cycles_completed=$((num_cycles_completed+1))
   fi
 done


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- An array index of 'cycle_statue' was missing in the conditional statement of the launch script (launch_FV3LAM_wflow.sh).
- An array index is added to 'cycle_status'.

## TESTS CONDUCTED: 


<img width="1015" alt="fix_launch" src="https://user-images.githubusercontent.com/60152248/121875058-03938800-ccd6-11eb-8084-c6b0d5196a72.png">


## ISSUE: 
Fixes issue mentioned in #512 