### PR TITLE
Add /atmos to HPSS path for GFS grib2 files after certain date

### DIFF
--- a/ush/get_extrn_mdl_file_dir_info.sh
+++ b/ush/get_extrn_mdl_file_dir_info.sh
@@ -920,12 +920,12 @@ workflow to look for the external model files in a user-staged directory."
 
     arcv_fmt="tar"
     
-    if [ "${cdate_FV3LAM}" -lt "2021032100" ]; then
-    arcvrel_dir="./gfs.${yyyymmdd}/${hh}"
-    else
-    arcvrel_dir="./gfs.${yyyymmdd}/${hh}/atmos"
+    slash_atmos_or_null=""
+    if [ "${cdate_FV3LAM}" -ge "2021032100" ]; then
+      slash_atmos_or_null="/atmos"
     fi
-
+    arcvrel_dir="./gfs.${yyyymmdd}/${hh}${slash_atmos_or_null}"
+     
     is_array arcv_fns
     if [ "$?" = "0" ]; then
       suffix=".${arcv_fmt}"

--- a/ush/get_extrn_mdl_file_dir_info.sh
+++ b/ush/get_extrn_mdl_file_dir_info.sh
@@ -919,7 +919,12 @@ workflow to look for the external model files in a user-staged directory."
     fi
 
     arcv_fmt="tar"
+    
+    if [ "${cdate_FV3LAM}" -lt "2021032100" ]; then
     arcvrel_dir="./gfs.${yyyymmdd}/${hh}"
+    else
+    arcvrel_dir="./gfs.${yyyymmdd}/${hh}/atmos"
+    fi
 
     is_array arcv_fns
     if [ "$?" = "0" ]; then


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Add "atmos" to the HPSS path for FV3GFS data after March 20th, 2021.

## TESTS CONDUCTED: 
Tests one day before an after the change on Hera.

## ISSUE (optional): 
This resolves Issue #514.

