### PR TITLE
[RRFS_baseline] Fix missing index bug in launch script

### DIFF
--- a/ush/launch_FV3LAM_wflow.sh
+++ b/ush/launch_FV3LAM_wflow.sh
@@ -316,7 +316,7 @@ done <<< "${rocotostat_output}"
 num_cycles_total=${#cycle_str[@]}
 num_cycles_completed=0
 for (( i=0; i<=$((num_cycles_total-1)); i++ )); do
-  if [ "${cycle_status}" = "Done" ]; then
+  if [ "${cycle_status[i]}" = "Done" ]; then
     num_cycles_completed=$((num_cycles_completed+1))
   fi
 done


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This is a duplicate of PR #513 into the develop branch, but this is for the RRFS_baseline branch.  This bug causes the launch script to work incorrectly when more than one cycle is being run.

## TESTS CONDUCTED: 
None.  Assuming the tests in PR #513 are sufficient.
