### PR TITLE
Bug fixes for workflow xml template and launch script

### DIFF
--- a/ush/launch_FV3LAM_wflow.sh
+++ b/ush/launch_FV3LAM_wflow.sh
@@ -316,7 +316,7 @@ done <<< "${rocotostat_output}"
 num_cycles_total=${#cycle_str[@]}
 num_cycles_completed=0
 for (( i=0; i<=$((num_cycles_total-1)); i++ )); do
-  if [ "${cycle_status}" = "Done" ]; then
+  if [ "${cycle_status[i]}" = "Done" ]; then
     num_cycles_completed=$((num_cycles_completed+1))
   fi
 done

--- a/ush/templates/FV3LAM_wflow.xml
+++ b/ush/templates/FV3LAM_wflow.xml
@@ -861,7 +861,7 @@ the <task> tag to be identical to the ones above for other output times.
 
 {%- if run_task_vx_gridstat %}
 <!--
-     ************************************************************************
+************************************************************************
 ************************************************************************
 -->
   <task name="&VX_GRIDSTAT_RETOP_TN;" maxtries="{{ maxtries_vx_gridstat_retop }}">
@@ -900,6 +900,7 @@ the <task> tag to be identical to the ones above for other output times.
   </task>
 {%- endif %}
 
+{%- if run_task_vx_gridstat %}
 <!--
 ************************************************************************
 ************************************************************************


### PR DESCRIPTION
## DESCRIPTION OF CHANGES:
This PR bundles together two bug fixes:
1) There is a missing index for an array in the launch script launch_FV3LAM_wflow.sh that causes the script to work incorrectly when more than one cycle is being run.  Add the missing index.  Note that this was fixed in the develop branch via PR #513.
2) There is a missing jinja2 if-statement in the template file FV3LAM_wflow.xml that causes the workflow generation script generate_FV3LAM_wflow.xml to fail.  This was caused by commit #[57c2aed](https://github.com/NOAA-EMC/regional_workflow/commit/57c2aed40cb1e9ee07812078027787fb5bde6d98) (without a PR?) into the RRFS_baseline branch.  Add the missing if-statement.

## TESTS CONDUCTED: 
* No test was conducted for the bug in launch_FV3LAM_wflow.sh.  Assuming that the tests conducted for PR #513 are sufficient.
* A workflow XML was successfully generated using the generate_FV3LAM_wflow.sh script after replacing the if-statement bug.