### PR TITLE
Changes required to produce the diag_table file at forecast run time.

### DIFF
--- a/scripts/exregional_make_grid.sh
+++ b/scripts/exregional_make_grid.sh
@@ -19,7 +19,6 @@
 . $USHDIR/make_grid_mosaic_file.sh
 . $USHDIR/link_fix.sh
 . $USHDIR/set_FV3nml_sfc_climo_filenames.sh
-. $USHDIR/create_diag_table_files.sh
 #
 #-----------------------------------------------------------------------
 #
@@ -647,10 +646,6 @@ failed."
 set_FV3nml_sfc_climo_filenames || print_err_msg_exit "\
 Call to function to set surface climatology file names in the FV3 namelist
 file failed."
-
-create_diag_table_files || print_err_msg_exit "\
-Call to function to create a diagnostics table file under each cycle
-directory failed."
 #
 #-----------------------------------------------------------------------
 #

--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -18,6 +18,7 @@
 #-----------------------------------------------------------------------
 #
 . $USHDIR/create_model_configure_file.sh
+. $USHDIR/create_diag_table_file.sh
 #
 #-----------------------------------------------------------------------
 #
@@ -471,6 +472,19 @@ create_model_configure_file \
 Call to function to create a model configuration file for the current
 cycle's (cdate) run directory (run_dir) failed:
   cdate = \"${cdate}\"
+  run_dir = \"${run_dir}\""
+#
+#-----------------------------------------------------------------------
+#
+# Call the function that creates the model configuration file within each
+# cycle directory.
+#
+#-----------------------------------------------------------------------
+#
+create_diag_table_file \
+  run_dir="${run_dir}" || print_err_msg_exit "\
+Call to function to create a diag table file for the current
+cycle's (cdate) run directory (run_dir) failed:
   run_dir = \"${run_dir}\""
 #
 #-----------------------------------------------------------------------

--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -483,8 +483,8 @@ cycle's (cdate) run directory (run_dir) failed:
 #
 create_diag_table_file \
   run_dir="${run_dir}" || print_err_msg_exit "\
-Call to function to create a diag table file for the current
-cycle's (cdate) run directory (run_dir) failed:
+Call to function to create a diag table file for the current cycle's 
+(cdate) run directory (run_dir) failed:
   run_dir = \"${run_dir}\""
 #
 #-----------------------------------------------------------------------

--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -476,8 +476,8 @@ cycle's (cdate) run directory (run_dir) failed:
 #
 #-----------------------------------------------------------------------
 #
-# Call the function that creates the model configuration file within each
-# cycle directory.
+# Call the function that creates the diag_table file within each cycle 
+# directory.
 #
 #-----------------------------------------------------------------------
 #

--- a/ush/create_diag_table_file.sh
+++ b/ush/create_diag_table_file.sh
@@ -78,7 +78,7 @@ function create_diag_table_file() {
 #
   print_info_msg "$VERBOSE" "                                            
 Creating a diagnostics table file (\"${DIAG_TABLE_FN}\") in the specified
-run directory..."
+run directory...
 
   run_dir = \"${run_dir}\""
 
@@ -94,7 +94,7 @@ to create:
     diag_table_fp = \"${diag_table_fp}\""
 
     settings="
-    starttime: !datetime ${ALL_CDATES[$i]}
+    starttime: !datetime ${CDATE}
     cres: ${CRES}"
 
     $USHDIR/fill_jinja_template.py -q -u "${settings}" -t "${DIAG_TABLE_TMPL_FP}" -o "${diag_table_fp}" || \

--- a/ush/create_diag_table_file.sh
+++ b/ush/create_diag_table_file.sh
@@ -94,8 +94,8 @@ to create:
     diag_table_fp = \"${diag_table_fp}\""
 
     settings="
-    starttime: !datetime ${CDATE}
-    cres: ${CRES}"
+starttime: !datetime ${CDATE}
+cres: ${CRES}"
 
     $USHDIR/fill_jinja_template.py -q -u "${settings}" -t "${DIAG_TABLE_TMPL_FP}" -o "${diag_table_fp}" || \
     print_err_msg_exit "

--- a/ush/create_diag_table_file.sh
+++ b/ush/create_diag_table_file.sh
@@ -6,7 +6,7 @@
 #
 #-----------------------------------------------------------------------
 #
-function create_diag_table_files() {
+function create_diag_table_file() {
 #
 #-----------------------------------------------------------------------
 #
@@ -45,7 +45,9 @@ function create_diag_table_files() {
 #
 #-----------------------------------------------------------------------
 #
-  local valid_args=()
+  local valid_args=( \
+    "run_dir" \
+    )
   process_args valid_args "$@"
 #
 #-----------------------------------------------------------------------
@@ -65,28 +67,26 @@ function create_diag_table_files() {
 #-----------------------------------------------------------------------
 #
   local i \
-        cdate \
-        cycle_dir \
         diag_table_fp \
         settings
 #
 #-----------------------------------------------------------------------
 #
-# Create a diagnostics table file within each cycle directory.
+# Create a diagnostics table file within the specified run directory.
 #
 #-----------------------------------------------------------------------
 #
   print_info_msg "$VERBOSE" "                                            
-Creating a diagnostics table file (\"${DIAG_TABLE_FN}\") within each cycle
-directory..."                                                      
+Creating a diagnostics table file (\"${DIAG_TABLE_FN}\") in the specified
+run directory..."
 
-  for (( i=0; i<${NUM_CYCLES}; i++ )); do
+  run_dir = \"${run_dir}\""
 
-    cdate="${ALL_CDATES[$i]}"
-    cycle_dir="${CYCLE_BASEDIR}/$cdate"
-
-    diag_table_fp="${cycle_dir}/${DIAG_TABLE_FN}"
+# Copy template diag_table file from the templates directory to the 
+# run directory.
+    diag_table_fp="${run_dir}/${DIAG_TABLE_FN}"
     print_info_msg "$VERBOSE" "
+
 Using the template diagnostics table file:
 
     diag_table_tmpl_fp = ${DIAG_TABLE_TMPL_FP}
@@ -96,9 +96,8 @@ to create:
     diag_table_fp = \"${diag_table_fp}\""
 
     settings="
-  starttime: !datetime ${ALL_CDATES[$i]}
-  cres: ${CRES}
-"
+    starttime: !datetime ${ALL_CDATES[$i]}
+    cres: ${CRES}"
 
     $USHDIR/fill_jinja_template.py -q -u "${settings}" -t "${DIAG_TABLE_TMPL_FP}" -o "${diag_table_fp}" || \
     print_err_msg_exit "
@@ -109,7 +108,6 @@ fill_jinja_template.py failed!
 !!!!!!!!!!!!!!!!!
 "
 
-  done
 #
 #-----------------------------------------------------------------------
 #

--- a/ush/create_diag_table_file.sh
+++ b/ush/create_diag_table_file.sh
@@ -82,8 +82,6 @@ run directory..."
 
   run_dir = \"${run_dir}\""
 
-# Copy template diag_table file from the templates directory to the 
-# run directory.
     diag_table_fp="${run_dir}/${DIAG_TABLE_FN}"
     print_info_msg "$VERBOSE" "
 

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -47,7 +47,6 @@ ushdir="${scrfunc_dir}"
 #
 . $ushdir/source_util_funcs.sh
 . $ushdir/set_FV3nml_sfc_climo_filenames.sh
-. $ushdir/create_diag_table_files.sh
 #
 #-----------------------------------------------------------------------
 #
@@ -378,21 +377,6 @@ are:
   Namelist settings specified on command line:
     settings =
 $settings"
-#
-#-----------------------------------------------------------------------
-#
-# Create the cycle directories.
-#
-#-----------------------------------------------------------------------
-#
-print_info_msg "$VERBOSE" "
-Creating the cycle directories..."
-
-for (( i=0; i<${NUM_CYCLES}; i++ )); do
-  cdate="${ALL_CDATES[$i]}"
-  cycle_dir="${CYCLE_BASEDIR}/$cdate"
-  mkdir_vrfy -p "${cycle_dir}"
-done
 #
 #-----------------------------------------------------------------------
 #
@@ -791,10 +775,6 @@ if [ "${RUN_TASK_MAKE_GRID}" = "FALSE" ]; then
   set_FV3nml_sfc_climo_filenames || print_err_msg_exit "\
 Call to function to set surface climatology file names in the FV3 namelist
 file failed."
-
-  create_diag_table_files || print_err_msg_exit "\
-Call to function to create a diagnostics table file under each cycle 
-directory failed."
 
 fi
 #

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -734,7 +734,7 @@ NUM_CYCLES="${#ALL_CDATES[@]}"
 if [ $NUM_CYCLES -gt 30 ] ; then
   unset ALL_CDATES
   print_info_msg "$VERBOSE" "
-Too many cycles in ALL_CDATES, defining in abbreviated form."
+Too many cycles in ALL_CDATES to list, redefining in abbreviated form."
 ALL_CDATES="${DATE_FIRST_CYCL}${CYCL_HRS[0]}...${DATE_LAST_CYCL}${CYCL_HRS[-1]}"
 fi
 #

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -730,6 +730,13 @@ set_cycle_dates \
   output_varname_all_cdates="ALL_CDATES"
 
 NUM_CYCLES="${#ALL_CDATES[@]}"
+
+if [ $NUM_CYCLES -gt 30 ] ; then
+unset ALL_CDATES
+print_info_msg "$VERBOSE" "
+Too many cycles in ALL_CDATES, defining in abbreviated form."
+ALL_CDATES="${DATE_FIRST_CYCL}${CYCL_HRS[0]}...${DATE_LAST_CYCL}${CYCL_HRS[-1]}"
+fi
 #
 #-----------------------------------------------------------------------
 #

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -732,8 +732,8 @@ set_cycle_dates \
 NUM_CYCLES="${#ALL_CDATES[@]}"
 
 if [ $NUM_CYCLES -gt 30 ] ; then
-unset ALL_CDATES
-print_info_msg "$VERBOSE" "
+  unset ALL_CDATES
+  print_info_msg "$VERBOSE" "
 Too many cycles in ALL_CDATES, defining in abbreviated form."
 ALL_CDATES="${DATE_FIRST_CYCL}${CYCL_HRS[0]}...${DATE_LAST_CYCL}${CYCL_HRS[-1]}"
 fi


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR creates the diag_table file during the forecast task instead of when the grid generation script is run.  It contains the same changes as PR#349, but includes the compromise solution for ALL_CDATES based on the size of NUM_CYCLES.

## TESTS CONDUCTED: 
Tested on Hera with single and multiple cycles to ensure proper creation of diag_table files and ALL_CDATES information in var_defns.sh as a function of NUM_CYCLES.