### PR TITLE
Update met version and workflow template for WCOSS

### DIFF
--- a/modulefiles/tasks/wcoss_dell_p3/run_vx.local
+++ b/modulefiles/tasks/wcoss_dell_p3/run_vx.local
@@ -3,4 +3,4 @@
 module unload netcdf
 
 module use /gpfs/dell2/emc/verification/noscrub/emc.metplus/modulefiles
-module load met/9.1
+module load met/10.0.0

--- a/ush/templates/FV3LAM_wflow.xml
+++ b/ush/templates/FV3LAM_wflow.xml
@@ -784,13 +784,7 @@ the <task> tag to be identical to the ones above for other output times.
   <task name="&VX_GRIDSTAT_TN;" maxtries="{{ maxtries_vx_gridstat }}">
 
     &RSRV_DEFAULT;
-  {%- if machine in ["WCOSS_CRAY"] %}
-    <shared/>
-  {%- endif %}
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSDIR;/JREGIONAL_RUN_VX_GRIDSTAT"</command>
-  {%- if machine in ["WCOSS_DELL_P3"] %}
-    <memory>2048M</memory><native>-R affinity[core]</native>
-  {%- endif %}
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
@@ -826,13 +820,7 @@ the <task> tag to be identical to the ones above for other output times.
   <task name="&VX_GRIDSTAT_REFC_TN;" maxtries="{{ maxtries_vx_gridstat_refc }}">
 
     &RSRV_DEFAULT;
-  {%- if machine in ["WCOSS_CRAY"] %}
-    <shared/>
-  {%- endif %}
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSDIR;/JREGIONAL_RUN_VX_GRIDSTAT"</command>
-  {%- if machine in ["WCOSS_DELL_P3"] %}
-    <memory>2048M</memory><native>-R affinity[core]</native>
-  {%- endif %}
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
@@ -861,19 +849,13 @@ the <task> tag to be identical to the ones above for other output times.
 
 {%- if run_task_vx_gridstat %}
 <!--
-     ************************************************************************
+************************************************************************
 ************************************************************************
 -->
   <task name="&VX_GRIDSTAT_RETOP_TN;" maxtries="{{ maxtries_vx_gridstat_retop }}">
 
     &RSRV_DEFAULT;
-  {%- if machine in ["WCOSS_CRAY"] %}
-    <shared/>
-  {%- endif %}
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSDIR;/JREGIONAL_RUN_VX_GRIDSTAT"</command>
-  {%- if machine in ["WCOSS_DELL_P3"] %}
-    <memory>2048M</memory><native>-R affinity[core]</native>
-  {%- endif %}
     <nodes>{{ nnodes_vx_gridstat }}:ppn={{ ppn_vx_gridstat }}</nodes>
     <walltime>{{ wtime_vx_gridstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>
@@ -1004,13 +986,7 @@ the <task> tag to be identical to the ones above for other output times.
   <task name="&VX_POINTSTAT_TN;" maxtries="{{ maxtries_vx_pointstat }}">
 
     &RSRV_DEFAULT;
-  {%- if machine in ["WCOSS_CRAY"] %}
-    <shared/>
-  {%- endif %}
     <command>&LOAD_MODULES_RUN_TASK_FP; "&VX_TN;" "&JOBSDIR;/JREGIONAL_RUN_VX_POINTSTAT"</command>
-  {%- if machine in ["WCOSS_DELL_P3"] %}
-    <memory>2048M</memory><native>-R affinity[core]</native>
-  {%- endif %}
     <nodes>{{ nnodes_vx_pointstat }}:ppn={{ ppn_vx_pointstat }}</nodes>
     <walltime>{{ wtime_vx_pointstat }}</walltime>
     <nodesize>&NCORES_PER_NODE;</nodesize>


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Since the version of MET was updated to 10.0 on Hera, its version on WCOSS are updated to 10.0.0.
- Since some verification tasks in the workflow template were modified from hpss queue to default queue, some commands only for the WCOSS dell and cray in the corresponding tasks are removed.

## TESTS CONDUCTED: 
GST + verification on the wcoss dell

## ISSUE: 
Fixes issue mentioned in #534.
Related to PR https://github.com/NOAA-EMC/regional_workflow/pull/528.