### PR TITLE
Update syntax for latest version of lmod.

### DIFF
--- a/modulefiles/tasks/hera/make_grid.local
+++ b/modulefiles/tasks/hera/make_grid.local
@@ -2,5 +2,5 @@
 module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
 if [module-info mode load] {
-  system "conda activate regional_workflow"
+  puts "conda activate regional_workflow"
 }

--- a/modulefiles/tasks/hera/make_grid.local
+++ b/modulefiles/tasks/hera/make_grid.local
@@ -1,6 +1,5 @@
 #%Module
 module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
-if [module-info mode load] {
-  puts "conda activate regional_workflow"
-}
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/hera/make_ics.local
+++ b/modulefiles/tasks/hera/make_ics.local
@@ -2,5 +2,5 @@
 module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
 if [module-info mode load] {
-  system "conda activate regional_workflow"
+  puts "conda activate regional_workflow"
 }

--- a/modulefiles/tasks/hera/make_ics.local
+++ b/modulefiles/tasks/hera/make_ics.local
@@ -1,6 +1,5 @@
 #%Module
 module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
-if [module-info mode load] {
-  puts "conda activate regional_workflow"
-}
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/hera/make_lbcs.local
+++ b/modulefiles/tasks/hera/make_lbcs.local
@@ -2,5 +2,5 @@
 module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
 if [module-info mode load] {
-  system "conda activate regional_workflow"
+  puts "conda activate regional_workflow"
 }

--- a/modulefiles/tasks/hera/make_lbcs.local
+++ b/modulefiles/tasks/hera/make_lbcs.local
@@ -1,6 +1,5 @@
 #%Module
 module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
-if [module-info mode load] {
-  puts "conda activate regional_workflow"
-}
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/hera/run_fcst.local
+++ b/modulefiles/tasks/hera/run_fcst.local
@@ -2,5 +2,5 @@
 module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
 if [module-info mode load] {
-  system "conda activate regional_workflow"
+  puts "conda activate regional_workflow"
 }

--- a/modulefiles/tasks/hera/run_fcst.local
+++ b/modulefiles/tasks/hera/run_fcst.local
@@ -1,6 +1,5 @@
 #%Module
 module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
-if [module-info mode load] {
-  puts "conda activate regional_workflow"
-}
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/jet/make_grid.local
+++ b/modulefiles/tasks/jet/make_grid.local
@@ -1,6 +1,5 @@
 #%Module
 module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
-if [module-info mode load] {
-  system "conda activate regional_workflow"
-}
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/jet/make_ics.local
+++ b/modulefiles/tasks/jet/make_ics.local
@@ -3,6 +3,5 @@ module load wgrib2/2.0.8
 
 module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
-if [module-info mode load] {
-  system "conda activate regional_workflow"
-}
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/jet/make_lbcs.local
+++ b/modulefiles/tasks/jet/make_lbcs.local
@@ -3,6 +3,5 @@ module load wgrib2/2.0.8
 
 module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
-if [module-info mode load] {
-  system "conda activate regional_workflow"
-}
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/jet/run_fcst.local
+++ b/modulefiles/tasks/jet/run_fcst.local
@@ -1,6 +1,5 @@
 #%Module
 module use -a /contrib/miniconda3/modulefiles
 module load miniconda3
-if [module-info mode load] {
-  system "conda activate regional_workflow"
-}
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/orion/make_grid.local
+++ b/modulefiles/tasks/orion/make_grid.local
@@ -1,6 +1,5 @@
 #%Module
 module use -a /apps/contrib/miniconda3-noaa-gsl/modulefiles
 module load miniconda3
-if [module-info mode load] {
-  system "conda activate regional_workflow"
-}
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/orion/make_ics.local
+++ b/modulefiles/tasks/orion/make_ics.local
@@ -1,6 +1,5 @@
 #%Module
 module use -a /apps/contrib/miniconda3-noaa-gsl/modulefiles
 module load miniconda3
-if [module-info mode load] {
-  system "conda activate regional_workflow"
-}
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/orion/make_lbcs.local
+++ b/modulefiles/tasks/orion/make_lbcs.local
@@ -1,6 +1,5 @@
 #%Module
 module use -a /apps/contrib/miniconda3-noaa-gsl/modulefiles
 module load miniconda3
-if [module-info mode load] {
-  system "conda activate regional_workflow"
-}
+
+setenv SRW_ENV regional_workflow

--- a/modulefiles/tasks/orion/run_fcst.local
+++ b/modulefiles/tasks/orion/run_fcst.local
@@ -1,6 +1,5 @@
 #%Module
 module use -a /apps/contrib/miniconda3-noaa-gsl/modulefiles
 module load miniconda3
-if [module-info mode load] {
-  system "conda activate regional_workflow"
-}
+
+setenv SRW_ENV regional_workflow

--- a/ush/load_modules_run_task.sh
+++ b/ush/load_modules_run_task.sh
@@ -321,6 +321,17 @@ ules_dir) for the specified task (task_name) failed:
   module list
 
 #fi #End if statement for tasks that load no modules
+
+# Modules that use conda and need an environment activated will set the
+# SRW_ENV variable to the name of the environment to be activated. That
+# must be done within the script, and not inside the module. Do that
+# now.
+
+if [ -n "${SRW_ENV:-}" ] ; then
+  conda activate ${SRW_ENV}
+fi
+
+
 #
 #-----------------------------------------------------------------------
 #


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR addresses an error that occurs at run time ```ModuleNotFoundError: No module named 'f90nml'```. A similar error may appear in any of the tasks that use a conda environment, and could potentially list `jinja2` instead.

The version of lmod on Hera was updated. The behavior of the `system` command has changed and now runs only in a subshell. As an lmod-version-independent fix, the module will no longer activate a conda environment, but will set the conda environment that should be activated through an environment variable, then the script will activate any required conda environment. 

Note: Users who do not run with Rocoto, but still use these modules, will have an extra step of activating the environment manually.

## TESTS CONDUCTED: 
I built and ran a single WE2E test successfully on Hera with these modifications. I did not test on other platforms.

