### PR TITLE
Copy and link NEMS field dictionary file

### DIFF
--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -445,6 +445,10 @@ create_symlink_to_file target="${NEMS_CONFIG_FP}" \
                        symlink="${run_dir}/${NEMS_CONFIG_FN}" \
                        relative="${relative_link_flag}"
 
+create_symlink_to_file target="${FIELD_DICT_FP}" \
+                       symlink="${run_dir}/${FIELD_DICT_FN}" \
+                       relative="${relative_link_flag}"
+
 if [ ${WRITE_DOPOST} = "TRUE" ]; then
   cp_vrfy ${EMC_POST_DIR}/parm/nam_micro_lookup.dat ./eta_micro_lookup.dat
   if [ ${USE_CUSTOM_POST_CONFIG_FILE} = "TRUE" ]; then

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -558,6 +558,15 @@ Copying the CCPP physics suite definition XML file from its location in
 the forecast model directory sturcture to the experiment directory..."
 cp_vrfy "${CCPP_PHYS_SUITE_IN_CCPP_FP}" "${CCPP_PHYS_SUITE_FP}"
 #
+# Copy the field dictionary file from its location in the
+# clone of the FV3 code repository to the experiment directory (EXPT-
+# DIR).
+#
+print_info_msg "$VERBOSE" "
+Copying the field dictionary file from its location in the forecast
+model directory sturcture to the experiment directory..."
+cp_vrfy "${FIELD_DICT_IN_UWM_FP}" "${FIELD_DICT_FP}"
+#
 #-----------------------------------------------------------------------
 #
 # Set parameters in the FV3-LAM namelist file.

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -1445,6 +1445,29 @@ fi
 #
 #-----------------------------------------------------------------------
 #
+# Set:
+#
+# 1) the variable FIELD_DICT_FN to the name of the field dictionary
+#    file.
+# 2) the variable FIELD_DICT_IN_UWM_FP to the full path of this
+#    file in the forecast model's directory structure.
+# 3) the variable FIELD_DICT_FP to the full path of this file in
+#    the experiment directory.
+#
+#-----------------------------------------------------------------------
+#
+FIELD_DICT_FN="fd_nems.yaml"
+FIELD_DICT_IN_UWM_FP="${UFS_WTHR_MDL_DIR}/tests/parm/${FIELD_DICT_FN}"
+FIELD_DICT_FP="${EXPTDIR}/${FIELD_DICT_FN}"
+if [ ! -f "${FIELD_DICT_IN_UWM_FP}" ]; then
+  print_err_msg_exit "\
+The field dictionary file (FIELD_DICT_IN_UWM_FP) does not exist
+in the local clone of the ufs-weather-model:
+  FIELD_DICT_IN_UWM_FP = \"${FIELD_DICT_IN_UWM_FP}\""
+fi
+#
+#-----------------------------------------------------------------------
+#
 # Call the function that sets the ozone parameterization being used and
 # modifies associated parameters accordingly. 
 #
@@ -2690,6 +2713,10 @@ NEMS_CONFIG_TMPL_FP="${NEMS_CONFIG_TMPL_FP}"
 CCPP_PHYS_SUITE_FN="${CCPP_PHYS_SUITE_FN}"
 CCPP_PHYS_SUITE_IN_CCPP_FP="${CCPP_PHYS_SUITE_IN_CCPP_FP}"
 CCPP_PHYS_SUITE_FP="${CCPP_PHYS_SUITE_FP}"
+
+FIELD_DICT_FN="${FIELD_DICT_FN}"
+FIELD_DICT_IN_UWM_FP="${FIELD_DICT_IN_UWM_FP}"
+FIELD_DICT_FP="${FIELD_DICT_FP}"
 
 DATA_TABLE_FP="${DATA_TABLE_FP}"
 FIELD_TABLE_FP="${FIELD_TABLE_FP}"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The NEMS driver now requires fd_nems.yaml file. This change will copy field dictionary file from tests/parm into exptdir during generate workflow. Then Link field dictionary file into run_dir during run forecast. The change requires updates to the ufs-weather-model, which contains the fd_nems.yaml file in tests/parm directory.

## TESTS CONDUCTED: 
6 hour simulation using community run environment on Jet with RRFS_CONUS_3km grid and FV3_RRFS_v1beta ccpp physics suite. The run did not produce bit-for-bit results but this is likely due to the upgraded ufs-weather-model.

## DEPENDENCIES:
Add any links to external PRs. For example:
- https://github.com/ufs-community/ufs-weather-model (3b8bb78642f989d4e81e0975553285095667cc97)
- Updates to environment to support updated ufs-weather-model (incomplete). Each env file needs to be updated to cmake 3.18+ and include module file for fms. (i.e. Jet 'module load fms/2020.04.03'

## DOCUMENTATION:
This PR is a fix required by updates to NEMS.

## ISSUE: 
Resolves issue #544

## CONTRIBUTORS (optional): 
@danrosen25
@JeffBeck-NOAA 

