### PR TITLE
change input.nml for filter topo to fix task failure

### DIFF
--- a/scripts/exregional_make_orog.sh
+++ b/scripts/exregional_make_orog.sh
@@ -493,7 +493,6 @@ cat > "${filter_dir}/input.nml" <<EOF
   mask_field = "land_frac"
   regional = .true.
   stretch_fac = ${STRETCH_FAC}
-  refine_ratio = ${refine_ratio}
   res = $res
 /
 EOF


### PR DESCRIPTION


## DESCRIPTION OF CHANGES: 
Remove "refine_ratio = ${refine_ratio}" in scripts/exregional_make_orog.sh to fix filter_topo failure

## TESTS CONDUCTED: 

regional ESG grids/topography

## DEPENDENCIES:


## DOCUMENTATION:


## ISSUE (optional): 
Fixes issue mentioned in #546 

