### PR TITLE
Remove symbolic linking of diag_table when running in ensemble mode.

### DIFF
--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -515,22 +515,6 @@ Call to function to create a diag table file for the current cycle's
 #
 #-----------------------------------------------------------------------
 #
-# If running ensemble forecasts, create a link to the cycle-specific
-# diagnostic tables file in the cycle directory.  Note that this link
-# should not be made if not running ensemble forecasts because in that
-# case, the cycle directory is the run directory (and we would be creating
-# a symlink with the name of a file that already exists).
-#
-#-----------------------------------------------------------------------
-#
-if [ "${DO_ENSEMBLE}" = "TRUE" ]; then
-  create_symlink_to_file target="${cycle_dir}/${DIAG_TABLE_FN}" \
-                         symlink="${run_dir}/${DIAG_TABLE_FN}" \
-                         relative="${relative_link_flag}"
-fi
-#
-#-----------------------------------------------------------------------
-#
 # Run the FV3-LAM model.  Note that we have to launch the forecast from
 # the current cycle's directory because the FV3 executable will look for
 # input files in the current directory.  Since those files have been


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
PR #349 (via PR #533) moves diag_table creation from the grid generation step to the run_fcst portion of the workflow.  However, it also uses the "run_dir" location instead of "cycle_dir" as the target for the diag_table file.  While these two locations are identical for deterministic simulations, they are not the same when using the ensemble mode (due to member directories).  Therefore, the diag_table file should no longer be symbolically linked from the "cycle_dir" location to the "run_dir" directory in ensemble mode (the file is now copied directly to "run_dir" for each ensemble member).

## TESTS CONDUCTED: 
Successfully ran a deterministic and two-member ensemble simulation on Hera.

