### PR TITLE
Remove update of domains_stack_size from FV3.input.yml

### DIFF
--- a/ush/templates/FV3.input.yml
+++ b/ush/templates/FV3.input.yml
@@ -79,8 +79,6 @@ FV3_HRRR:
 FV3_GFS_2017_gfdlmp:
   atmos_model_nml:
     avg_max_length: 3600.0
-  fms_nml:
-    domains_stack_size: 1800200
   fv_core_nml: &gfs_2017_gfdlmp_fv_core
     agrid_vel_rst: False
     d4_bg: 0.15
@@ -175,8 +173,6 @@ FV3_GFS_2017_gfdlmp:
 FV3_GFS_2017_gfdlmp_regional:
   atmos_model_nml:
     avg_max_length: 3600.0
-  fms_nml:
-    domains_stack_size: 1800200
   fv_core_nml:
     <<: *gfs_2017_gfdlmp_fv_core
     k_split: 2
@@ -209,8 +205,6 @@ FV3_GFS_2017_gfdlmp_regional:
     <<: *gfs_gfdl_cloud_mp
 
 FV3_GFS_v15p2:
-  fms_nml:
-    domains_stack_size: 1800200
   fv_core_nml: &gfs_v15_fv_core
     agrid_vel_rst: False
     d2_bg_k1: 0.15
@@ -298,8 +292,6 @@ FV3_GFS_v16:
     fhouthf: 1
   cires_ugwp_nml:
     launch_level: 27
-  fms_nml:
-    domains_stack_size: 1800200
   fv_core_nml:
     <<: *gfs_v15_fv_core
     agrid_vel_rst: false
@@ -361,8 +353,6 @@ FV3_GFS_v16:
   surf_map_nml: !!python/none
 
 FV3_CPT_v0:
-  fms_nml:
-    domains_stack_size: 1800200
   fv_core_nml:
     <<: *gfs_v15_fv_core
     dnats: 0


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Removes the update of 'domains_stack_size' (3000000 -> 1800200) in FV3.input.yml to avoid mpp_domains_stack overflow in a high-resolution domain (RRFS_NA_3km).

## TESTS CONDUCTED: 
WE2E tests on Hera:
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
- grid_RRFS_NA_3km

## ISSUE: 
Fixes issue mentioned in #557 

## CONTRIBUTORS: 
@BenjaminBlake-NOAA 
