### PR TITLE
Add the pazi parameter option to the creation of the regional_esg_grid namelist; set pazi=-13.0 for the RRFS_NA_3km domain

### DIFF
--- a/scripts/exregional_make_grid.sh
+++ b/scripts/exregional_make_grid.sh
@@ -357,6 +357,7 @@ generation executable (exec_fp):
     'dely': ${DEL_ANGLE_Y_SG},
     'lx': ${NEG_NX_OF_DOM_WITH_WIDE_HALO},
     'ly': ${NEG_NY_OF_DOM_WITH_WIDE_HALO},
+    'pazi': ${PAZI},
  }
 "
 #

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -898,6 +898,9 @@ GFDLgrid_USE_GFDLgrid_RES_IN_FILENAMES=""
 # the regional grid before shaving the halo down to the width(s) expected
 # by the forecast model.  
 #
+# ESGgrid_PAZI:
+# The rotational parameter for the ESG grid (in degrees).
+#
 # In order to generate grid files containing halos that are 3-cell and
 # 4-cell wide and orography files with halos that are 0-cell and 3-cell
 # wide (all of which are required as inputs to the forecast model), the
@@ -952,6 +955,7 @@ ESGgrid_DELY=""
 ESGgrid_NX=""
 ESGgrid_NY=""
 ESGgrid_WIDE_HALO_WIDTH=""
+ESGgrid_PAZI=""
 #
 #-----------------------------------------------------------------------
 #

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -955,7 +955,7 @@ ESGgrid_DELY=""
 ESGgrid_NX=""
 ESGgrid_NY=""
 ESGgrid_WIDE_HALO_WIDTH=""
-ESGgrid_PAZI=""
+ESGgrid_PAZI="0.0"
 #
 #-----------------------------------------------------------------------
 #

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -955,7 +955,7 @@ ESGgrid_DELY=""
 ESGgrid_NX=""
 ESGgrid_NY=""
 ESGgrid_WIDE_HALO_WIDTH=""
-ESGgrid_PAZI="0.0"
+ESGgrid_PAZI=""
 #
 #-----------------------------------------------------------------------
 #

--- a/ush/set_gridparams_ESGgrid.sh
+++ b/ush/set_gridparams_ESGgrid.sh
@@ -55,10 +55,12 @@ function set_gridparams_ESGgrid() {
 "halo_width" \
 "delx" \
 "dely" \
+"pazi" \
 "output_varname_lon_ctr" \
 "output_varname_lat_ctr" \
 "output_varname_nx" \
 "output_varname_ny" \
+"output_varname_pazi" \
 "output_varname_halo_width" \
 "output_varname_stretch_factor" \
 "output_varname_del_angle_x_sg" \
@@ -153,6 +155,7 @@ function set_gridparams_ESGgrid() {
   eval ${output_varname_ny}="${ny}"
   eval ${output_varname_halo_width}="${halo_width}"
   eval ${output_varname_stretch_factor}="${stretch_factor}"
+  eval ${output_varname_pazi}="${pazi}"
   eval ${output_varname_del_angle_x_sg}="${del_angle_x_sg}"
   eval ${output_varname_del_angle_y_sg}="${del_angle_y_sg}"
   eval ${output_varname_neg_nx_of_dom_with_wide_halo}="${neg_nx_of_dom_with_wide_halo}"

--- a/ush/set_predef_grid_params.sh
+++ b/ush/set_predef_grid_params.sh
@@ -1187,6 +1187,8 @@ case ${PREDEF_GRID_NAME} in
   ESGgrid_NX=3640
   ESGgrid_NY=2520
 
+  ESGgrid_PAZI=-13.0
+
   ESGgrid_WIDE_HALO_WIDTH=6
 
   DT_ATMOS="${DT_ATMOS:-36}"

--- a/ush/set_predef_grid_params.sh
+++ b/ush/set_predef_grid_params.sh
@@ -112,6 +112,8 @@ case ${PREDEF_GRID_NAME} in
   ESGgrid_NX="202"
   ESGgrid_NY="116"
 
+  ESGgrid_PAZI="0.0"
+
   ESGgrid_WIDE_HALO_WIDTH="6"
 
   DT_ATMOS="${DT_ATMOS:-40}"
@@ -156,6 +158,8 @@ case ${PREDEF_GRID_NAME} in
   ESGgrid_NX="396"
   ESGgrid_NY="232"
 
+  ESGgrid_PAZI="0.0"
+  
   ESGgrid_WIDE_HALO_WIDTH="6"
 
   DT_ATMOS="${DT_ATMOS:-45}"
@@ -199,6 +203,8 @@ case ${PREDEF_GRID_NAME} in
 
   ESGgrid_NX="1748"
   ESGgrid_NY="1038"
+
+  ESGgrid_PAZI="0.0"
 
   ESGgrid_WIDE_HALO_WIDTH="6"
 
@@ -244,6 +250,8 @@ case ${PREDEF_GRID_NAME} in
   ESGgrid_NX="840"
   ESGgrid_NY="600"
 
+  ESGgrid_PAZI="0.0"
+  
   ESGgrid_WIDE_HALO_WIDTH="6"
 
   DT_ATMOS="${DT_ATMOS:-40}"
@@ -291,6 +299,8 @@ case ${PREDEF_GRID_NAME} in
   ESGgrid_NX="320"
   ESGgrid_NY="240"
 
+  ESGgrid_PAZI="0.0"
+  
   ESGgrid_WIDE_HALO_WIDTH="6"
 
 #  DT_ATMOS="${DT_ATMOS:-50}"
@@ -409,6 +419,8 @@ case ${PREDEF_GRID_NAME} in
   ESGgrid_NX="1380"
   ESGgrid_NY="1020"
 
+  ESGgrid_PAZI="0.0"
+  
   ESGgrid_WIDE_HALO_WIDTH="6"
 
 #  DT_ATMOS="${DT_ATMOS:-50}"
@@ -638,6 +650,9 @@ case ${PREDEF_GRID_NAME} in
   ESGgrid_NX="1344" # Supergrid value 2704
   ESGgrid_NY="1152" # Supergrid value 2320
 
+# Rotation of the ESG grid in degrees.
+  ESGgrid_PAZI="0.0"
+
 # Number of halo points for a wide grid (before trimming)...this should almost always be 6 for now
 # Within the model we actually have a 4-point halo and a 3-point halo
   ESGgrid_WIDE_HALO_WIDTH="6"
@@ -712,6 +727,9 @@ case ${PREDEF_GRID_NAME} in
 # Divide "supergrid" values from /scratch2/BMC/det/kavulich/fix/fix_sar/hi/C768_grid.tile7.halo4.nc by 2 and subtract 8 to eliminate halo
   ESGgrid_NX="432" # Supergrid value 880
   ESGgrid_NY="360" # Supergrid value 736
+
+# Rotation of the ESG grid in degrees.
+  ESGgrid_PAZI="0.0"
 
 # Number of halo points for a wide grid (before trimming)...this should almost always be 6 for now
 # Within the model we actually have a 4-point halo and a 3-point halo
@@ -788,6 +806,9 @@ case ${PREDEF_GRID_NAME} in
   ESGgrid_NX="576" # Supergrid value 1168
   ESGgrid_NY="432" # Supergrid value 880
 
+# Rotation of the ESG grid in degrees.
+  ESGgrid_PAZI="0.0"
+
 # Number of halo points for a wide grid (before trimming)...this should almost always be 6 for now
 # Within the model we actually have a 4-point halo and a 3-point halo
   ESGgrid_WIDE_HALO_WIDTH="6"
@@ -863,6 +884,9 @@ case ${PREDEF_GRID_NAME} in
   ESGgrid_NX="432" # Supergrid value 880
   ESGgrid_NY="360" # Supergrid value 736
 
+# Rotation of the ESG grid in degrees.
+  ESGgrid_PAZI="0.0"
+
 # Number of halo points for a wide grid (before trimming)...this should almost always be 6 for now
 # Within the model we actually have a 4-point halo and a 3-point halo
   ESGgrid_WIDE_HALO_WIDTH="6"
@@ -930,6 +954,8 @@ case ${PREDEF_GRID_NAME} in
   ESGgrid_NX="345"
   ESGgrid_NY="230"
 
+  ESGgrid_PAZI="0.0"
+
   ESGgrid_WIDE_HALO_WIDTH="6"
 
   DT_ATMOS="${DT_ATMOS:-300}"
@@ -971,6 +997,8 @@ case ${PREDEF_GRID_NAME} in
 
   ESGgrid_NX="665"
   ESGgrid_NY="444"
+
+  ESGgrid_PAZI="0.0"
 
   ESGgrid_WIDE_HALO_WIDTH="6"
 
@@ -1014,6 +1042,8 @@ case ${PREDEF_GRID_NAME} in
   ESGgrid_NX="2880"
   ESGgrid_NY="1920"
 
+  ESGgrid_PAZI="0.0"
+
   ESGgrid_WIDE_HALO_WIDTH="6"
 
   DT_ATMOS="${DT_ATMOS:-40}"
@@ -1055,6 +1085,8 @@ case ${PREDEF_GRID_NAME} in
 
   ESGgrid_NX="74"
   ESGgrid_NY="51"
+
+  ESGgrid_PAZI="0.0"
 
   ESGgrid_WIDE_HALO_WIDTH="6"
 
@@ -1144,6 +1176,8 @@ case ${PREDEF_GRID_NAME} in
   ESGgrid_NX="960"
   ESGgrid_NY="960"
 
+  ESGgrid_PAZI="0.0"
+
   ESGgrid_WIDE_HALO_WIDTH="6"
 
   DT_ATMOS="${DT_ATMOS:-50}"
@@ -1187,7 +1221,7 @@ case ${PREDEF_GRID_NAME} in
   ESGgrid_NX=3640
   ESGgrid_NY=2520
 
-  ESGgrid_PAZI=-13.0
+  ESGgrid_PAZI="-13.0"
 
   ESGgrid_WIDE_HALO_WIDTH=6
 

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -2042,6 +2042,7 @@ elif [ "${GRID_GEN_METHOD}" = "ESGgrid" ]; then
     lat_ctr="${ESGgrid_LAT_CTR}" \
     nx="${ESGgrid_NX}" \
     ny="${ESGgrid_NY}" \
+    pazi="${ESGgrid_PAZI}" \
     halo_width="${ESGgrid_WIDE_HALO_WIDTH}" \
     delx="${ESGgrid_DELX}" \
     dely="${ESGgrid_DELY}" \

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -2050,6 +2050,7 @@ elif [ "${GRID_GEN_METHOD}" = "ESGgrid" ]; then
     output_varname_lat_ctr="LAT_CTR" \
     output_varname_nx="NX" \
     output_varname_ny="NY" \
+    output_varname_pazi="PAZI" \
     output_varname_halo_width="NHW" \
     output_varname_stretch_factor="STRETCH_FAC" \
     output_varname_del_angle_x_sg="DEL_ANGLE_X_SG" \
@@ -2778,6 +2779,7 @@ NX="${NX}"
 NY="${NY}"
 NHW="${NHW}"
 STRETCH_FAC="${STRETCH_FAC}"
+PAZI="${PAZI}"
 
 RES_IN_FIXLAM_FILENAMES="${RES_IN_FIXLAM_FILENAMES}"
 #

--- a/ush/templates/regional_grid.nml
+++ b/ush/templates/regional_grid.nml
@@ -73,6 +73,10 @@
 ! --
 ! Analogous to lx but in the y direction.
 !
+! pazi:
+! ----
+! Rotation angle for the ESG grid in degrees.
+!
 !***********************************************************************
 !
 
@@ -83,4 +87,5 @@
   dely = <dely>
   lx   = <lx>
   ly   = <ly>
+  pazi = <pazi>
 /


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Add the pazi parameter as a definable option to the workflow to allow for its addition to the regional_esg_grid namelist.  Set pazi to -13.0 for the RRFS_NA_3km domain to obtain the proper grid rotation angle.

## TESTS CONDUCTED: 
Test on Hera with the RRFS_NA_3km domain and with the RRFS_CONUS_3km domain, the latter of which does not have a rotation angle, but is correctly set to pazi=0.0.

## DOCUMENTATION:
Added in-line comments to explain the pazi parameter.

## ISSUE (optional): 
Resolves Issue #566.

## CONTRIBUTORS (optional): 
@BenjaminBlake-NOAA, @JacobCarley-NOAA, @gsketefian

