### PR TITLE
fix filter_topo failure when GWD orog is on

### DIFF
--- a/scripts/exregional_make_orog.sh
+++ b/scripts/exregional_make_orog.sh
@@ -325,11 +325,10 @@ if [ "${CCPP_PHYS_SUITE}" = "FV3_HRRR" ]; then
   tmp_dir="${OROG_DIR}/temp_orog_data"
   mkdir_vrfy -p ${tmp_dir}
   cd_vrfy ${tmp_dir}
-
-  mosaic_fn="${CRES}${DOT_OR_USCORE}mosaic.halo${NH4}.nc"
-  mosaic_fp="$FIXLAM/${mosaic_fn}"
-  grid_fn=$( get_charvar_from_netcdf "${mosaic_fp}" "gridfiles" )
-  grid_fp="${FIXLAM}/${grid_fn}"
+  mosaic_fn_gwd="${CRES}${DOT_OR_USCORE}mosaic.halo${NH4}.nc"
+  mosaic_fp_gwd="$FIXLAM/${mosaic_fn_gwd}"
+  grid_fn_gwd=$( get_charvar_from_netcdf "${mosaic_fp_gwd}" "gridfiles" )
+  grid_fp_gwd="${FIXLAM}/${grid_fn_gwd}"
   ls_fn="geo_em.d01.lat-lon.2.5m.HGT_M.nc"
   ss_fn="HGT.Beljaars_filtered.lat-lon.30s_res.nc"
   if [ "${MACHINE}" = "WCOSS_CRAY" ]; then
@@ -337,7 +336,7 @@ if [ "${CCPP_PHYS_SUITE}" = "FV3_HRRR" ]; then
   else
     relative_or_null="--relative"
   fi
-  ln_vrfy -fs ${relative_or_null} "${grid_fp}" "${tmp_dir}/${grid_fn}"
+  ln_vrfy -fs ${relative_or_null} "${grid_fp_gwd}" "${tmp_dir}/${grid_fn_gwd}"
   ln_vrfy -fs ${relative_or_null} "${FIXam}/${ls_fn}" "${tmp_dir}/${ls_fn}"
   ln_vrfy -fs ${relative_or_null} "${FIXam}/${ss_fn}" "${tmp_dir}/${ss_fn}"
 


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 
fix filter_topo failure when GWD orog is on 

## TESTS CONDUCTED: 
The changes have been tested for make_orog and it is confirmed to fix the filter_topo failure 

## DEPENDENCIES:
This PR is for Issue #568 

## DOCUMENTATION:
If this PR is contributing new capabilities that need to be documented, please also include updates to the RST files in the ufs-srweather-app repository (docs/UsersGuide/source) as supporting material.

## ISSUE (optional): 
If this PR is resolving or referencing one or more issues, in this repository or elewhere, list them here. For example, "Fixes issue mentioned in #123" or "Related to bug in https://github.com/NOAA-EMC/other_repository/pull/63"

## CONTRIBUTORS (optional): 
If others have contributed to this work aside from the PR author, list them here

