### PR TITLE
Set up the parameters for MET on WCOSS in run_WE2E_tests.sh

### DIFF
--- a/tests/WE2E/run_WE2E_tests.sh
+++ b/tests/WE2E/run_WE2E_tests.sh
@@ -950,8 +950,13 @@ external model files should be located has not been specified for this
 machine (MACHINE):
   MACHINE= \"${MACHINE}\""
     fi
-
+   
     EXTRN_MDL_SOURCE_BASEDIR_ICS="${extrn_mdl_source_basedir}/${EXTRN_MDL_NAME_ICS}"
+
+    if [ "${EXTRN_MDL_NAME_ICS}" = "FV3GFS" ] && [ "$MACHINE" = "HERA" ]; then
+      EXTRN_MDL_SOURCE_BASEDIR_ICS="${EXTRN_MDL_SOURCE_BASEDIR_ICS}/${FV3GFS_FILE_FMT_ICS}"
+    fi
+ 
     if [ "${EXTRN_MDL_NAME_ICS}" = "FV3GFS" ] || \
        [ "${EXTRN_MDL_NAME_ICS}" = "GSMGFS" ]; then
       if [ "${FV3GFS_FILE_FMT_ICS}" = "nemsio" ]; then
@@ -967,6 +972,11 @@ machine (MACHINE):
     fi
 
     EXTRN_MDL_SOURCE_BASEDIR_LBCS="${extrn_mdl_source_basedir}/${EXTRN_MDL_NAME_LBCS}"
+
+    if [ "${EXTRN_MDL_NAME_LBCS}" = "FV3GFS" ] && [ "$MACHINE" = "HERA" ]; then
+      EXTRN_MDL_SOURCE_BASEDIR_LBCS="${EXTRN_MDL_SOURCE_BASEDIR_LBCS}/${FV3GFS_FILE_FMT_LBCS}"
+    fi
+
 #
 # Make sure that the forecast length is evenly divisible by the interval
 # between the times at which the lateral boundary conditions will be

--- a/tests/WE2E/run_WE2E_tests.sh
+++ b/tests/WE2E/run_WE2E_tests.sh
@@ -1019,12 +1019,27 @@ EXTRN_MDL_FILES_LBCS=( $( printf "\"%s\" " "${EXTRN_MDL_FILES_LBCS[@]}" ))"
   if [ "${RUN_TASK_VX_GRIDSTAT}" = "TRUE" ] || \
      [ "${RUN_TASK_VX_POINTSTAT}" = "TRUE" ]; then
 
-    if [ "$MACHINE" = "HERA" ]; then
+    if [ "$MACHINE" = "WCOSS_CRAY" ]; then
+      met_install_dir="/gpfs/hps/nco/ops/nwprod/met.v9.1.3"
+      metplus_path="/gpfs/hps/nco/ops/nwprod/metplus.v3.1.1/METplus-3.1.1"
+      ccpa_obs_dir="/gpfs/hps3/emc/meso/noscrub/UFS_SRW_App/obs_data/ccpa/proc"
+      mrms_obs_dir="/gpfs/hps3/emc/meso/noscrub/UFS_SRW_App/obs_data/mrms/proc"
+      ndas_obs_dir="/gpfs/hps3/emc/meso/noscrub/UFS_SRW_App/obs_data/ndas/proc"
+      met_bin_exec="exec"
+    elif [ "$MACHINE" = "WCOSS_DELL_P3" ]; then
+      met_install_dir="/gpfs/dell2/emc/verification/noscrub/emc.metplus/met/10.0.0"
+      metplus_path="/gpfs/dell2/emc/verification/noscrub/emc.metplus/METplus/METplus-4.0.0"
+      ccpa_obs_dir="/gpfs/dell2/emc/modeling/noscrub/UFS_SRW_App/obs_data/ccpa/proc"
+      mrms_obs_dir="/gpfs/dell2/emc/modeling/noscrub/UFS_SRW_App/obs_data/mrms/proc"
+      ndas_obs_dir="/gpfs/dell2/emc/modeling/noscrub/UFS_SRW_App/obs_data/ndas/proc"
+      met_bin_exec="exec"
+    elif [ "$MACHINE" = "HERA" ]; then
       met_install_dir="/contrib/met/10.0.0"
       metplus_path="/contrib/METplus/METplus-4.0.0"
       ccpa_obs_dir="/scratch2/BMC/det/UFS_SRW_app/v1p0/obs_data/ccpa/proc"
       mrms_obs_dir="/scratch2/BMC/det/UFS_SRW_app/v1p0/obs_data/mrms/proc"
       ndas_obs_dir="/scratch2/BMC/det/UFS_SRW_app/v1p0/obs_data/ndas/proc"
+      met_bin_exec="bin"
     else
       print_err_msg_exit "\
 The MET and MET+ paths (MET_INSTALL_DIR and MET_INSTALL_DIR) or the observation directories
@@ -1040,7 +1055,8 @@ METPLUS_PATH=\"${metplus_path}\"
 MET_INSTALL_DIR=\"${met_install_dir}\"
 CCPA_OBS_DIR=\"${ccpa_obs_dir}\"
 MRMS_OBS_DIR=\"${mrms_obs_dir}\"
-NDAS_OBS_DIR=\"${ndas_obs_dir}\""
+NDAS_OBS_DIR=\"${ndas_obs_dir}\"
+MET_BIN_EXEC=\"${met_bin_exec}\""
 
   fi
 #


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Add the parameters for MET on WCOSS to the 'run_WE2E_tests.sh' script of WE2E.
- Update the directory structure of the user-staged external FV3GFS data on Hera.

## TESTS CONDUCTED: 
MET_verification test of WE2E on the wcoss dell and cray as well as Hera.

## ISSUE: 
Fixes issue mentioned in #573 
