### PR TITLE
The executable name and output prefixes of 'run_post' are parameterized

### DIFF
--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -276,7 +276,7 @@ EOF
 print_info_msg "$VERBOSE" "
 Starting post-processing for fhr = $fhr hr..."
 
-${APRUN} ${EXECDIR}/ncep_post < itag || print_err_msg_exit "\
+${APRUN} ${EXECDIR}/${POST_EXEC_FN} < itag || print_err_msg_exit "\
 Call to executable to run post for forecast hour $fhr returned with non-
 zero exit code."
 #
@@ -331,14 +331,23 @@ post_renamed_fn_suffix="f${fhr}${post_mn_or_null}.${tmmark}.grib2"
 cd_vrfy "${postprd_dir}"
 basetime=$( date --date "$yyyymmdd $hh" +%y%j%H%M )
 symlink_suffix="_${basetime}f${fhr}${post_mn}"
-fids=( "bgdawp" "bgrd3d" )
+fids=${POST_FIDS}
 for fid in "${fids[@]}"; do
   FID="${fid^^}"
+  if [ "${FID}" = "BGDAWP" ] || [ "${FID}" = "PRSLEV" ]; then
+    FID_OUT = "BGDAWQ"
+  elif [ "${FID}" = "BGRD3D" ] || [ "${FID}" = "NATLEV" ]; then
+    FID_OUT = "BGRD3D"
+  else
+    print_err_msg_exit "\
+The wrong FIDS_POST were set in config.sh:
+  FIDS_POST = \"${FIDS_POST}\""
+  fi
   post_orig_fn="${FID}.${post_fn_suffix}"
   post_renamed_fn="${NET}.t${cyc}z.${fid}${post_renamed_fn_suffix}"
   mv_vrfy ${tmp_dir}/${post_orig_fn} ${post_renamed_fn}
   create_symlink_to_file target="${post_renamed_fn}" \
-                         symlink="${FID}${symlink_suffix}" \
+                         symlink="${FID_OUT}${symlink_suffix}" \
                          relative="TRUE"
 done
 

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -335,16 +335,17 @@ fids=${POST_FIDS}
 for fid in "${fids[@]}"; do
   FID="${fid^^}"
   if [ "${FID}" = "BGDAWP" ] || [ "${FID}" = "PRSLEV" ]; then
-    FID_OUT="BGDAWQ"
+    fid_out="bgdawp"
   elif [ "${FID}" = "BGRD3D" ] || [ "${FID}" = "NATLEV" ]; then
-    FID_OUT="BGRD3D"
+    fid_out="bgrd3d"
   else
     print_err_msg_exit "\
 The wrong FIDS_POST were set in config.sh:
   FIDS_POST = \"${FIDS_POST}\""
   fi
+  FID_OUT="${fid_out^^}"
   post_orig_fn="${FID}.${post_fn_suffix}"
-  post_renamed_fn="${NET}.t${cyc}z.${fid}${post_renamed_fn_suffix}"
+  post_renamed_fn="${NET}.t${cyc}z.${fid_out}${post_renamed_fn_suffix}"
   mv_vrfy ${tmp_dir}/${post_orig_fn} ${post_renamed_fn}
   create_symlink_to_file target="${post_renamed_fn}" \
                          symlink="${FID_OUT}${symlink_suffix}" \

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -335,9 +335,9 @@ fids=${POST_FIDS}
 for fid in "${fids[@]}"; do
   FID="${fid^^}"
   if [ "${FID}" = "BGDAWP" ] || [ "${FID}" = "PRSLEV" ]; then
-    FID_OUT = "BGDAWQ"
+    FID_OUT="BGDAWQ"
   elif [ "${FID}" = "BGRD3D" ] || [ "${FID}" = "NATLEV" ]; then
-    FID_OUT = "BGRD3D"
+    FID_OUT="BGRD3D"
   else
     print_err_msg_exit "\
 The wrong FIDS_POST were set in config.sh:

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -340,8 +340,8 @@ for fid in "${fids[@]}"; do
     fid_out="bgrd3d"
   else
     print_err_msg_exit "\
-The wrong FIDS_POST were set in config.sh:
-  FIDS_POST = \"${FIDS_POST}\""
+The POST_FIDS were NOT set correctly in config.sh:
+  POST_FIDS = \"${POST_FIDS}\""
   fi
   FID_OUT="${fid_out^^}"
   post_orig_fn="${FID}.${post_fn_suffix}"

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -298,6 +298,12 @@ DOT_OR_USCORE="_"
 # FCST_MODEL:
 # Name of forecast model (default=ufs-weather-model)
 #
+# POST_EXEC_FN:
+# Name of the post-processing executable
+#
+# POST_FIDS:
+# Output file prefixes of post-processing 
+#
 # WFLOW_XML_FN:
 # Name of the rocoto workflow XML file that the experiment generation
 # script creates and that defines the workflow for the experiment.
@@ -350,6 +356,8 @@ NEMS_CONFIG_FN="nems.configure"
 FV3_EXEC_FN="ufs_model"
 
 FCST_MODEL="ufs-weather-model"
+POST_EXEC_FN="ncep_post"
+POST_FIDS=( "bgdawp" "bgrd3d" )
 
 WFLOW_XML_FN="FV3LAM_wflow.xml"
 GLOBAL_VAR_DEFNS_FN="var_defns.sh"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The executable name and output prefixes of the ‘run_post’ task are parameterized so that they can be specified in the configuration file with the new parameters POST_EXEC_FN and POST_FIDS.

## TESTS CONDUCTED: 
1. 6h GST tests with the current and latest ‘EMC_post’:
For the latest ‘EMC_post’: add the following two parameters to config.sh: 
POST_EXEC_FN=”upp.x”
POST_FIDS=( “prslev” “natlev” )

2. WE2E test: MET_verification

## ISSUE: 
Fixes issue mentioned in #576 

