### PR TITLE
Port verification tasks to run on Cheyenne

### DIFF
--- a/modulefiles/tasks/cheyenne/run_vx.local
+++ b/modulefiles/tasks/cheyenne/run_vx.local
@@ -1,0 +1,11 @@
+#%Module
+
+if [module-info mode load] {
+  system "ncar_pylib /glade/p/ral/jntp/UFS_SRW_app/ncar_pylib_20200427"
+}
+
+if [module-info mode remove] {
+  system "deactivate"
+}
+module use /glade/p/ral/jntp/MET/MET_releases/modulefiles
+module load met/10.0.0

--- a/tests/WE2E/run_WE2E_tests.sh
+++ b/tests/WE2E/run_WE2E_tests.sh
@@ -952,6 +952,9 @@ machine (MACHINE):
     fi
 
     EXTRN_MDL_SOURCE_BASEDIR_ICS="${extrn_mdl_source_basedir}/${EXTRN_MDL_NAME_ICS}"
+    if [ "${EXTRN_MDL_NAME_ICS}" = "FV3GFS" ] && [ "$MACHINE" = "HERA" ]; then
+      EXTRN_MDL_SOURCE_BASEDIR_ICS="${EXTRN_MDL_SOURCE_BASEDIR_ICS}/${FV3GFS_FILE_FMT_ICS}"
+    fi
     if [ "${EXTRN_MDL_NAME_ICS}" = "FV3GFS" ] || \
        [ "${EXTRN_MDL_NAME_ICS}" = "GSMGFS" ]; then
       if [ "${FV3GFS_FILE_FMT_ICS}" = "nemsio" ]; then
@@ -967,6 +970,9 @@ machine (MACHINE):
     fi
 
     EXTRN_MDL_SOURCE_BASEDIR_LBCS="${extrn_mdl_source_basedir}/${EXTRN_MDL_NAME_LBCS}"
+    if [ "${EXTRN_MDL_NAME_LBCS}" = "FV3GFS" ] && [ "$MACHINE" = "HERA" ]; then
+      EXTRN_MDL_SOURCE_BASEDIR_LBCS="${EXTRN_MDL_SOURCE_BASEDIR_LBCS}/${FV3GFS_FILE_FMT_LBCS}"
+    fi
 #
 # Make sure that the forecast length is evenly divisible by the interval
 # between the times at which the lateral boundary conditions will be
@@ -1017,14 +1023,22 @@ EXTRN_MDL_FILES_LBCS=( $( printf "\"%s\" " "${EXTRN_MDL_FILES_LBCS[@]}" ))"
 #-----------------------------------------------------------------------
 #
   if [ "${RUN_TASK_VX_GRIDSTAT}" = "TRUE" ] || \
-     [ "${RUN_TASK_VX_POINTSTAT}" = "TRUE" ]; then
+     [ "${RUN_TASK_VX_POINTSTAT}" = "TRUE" ] || \
+     [ "${RUN_TASK_VX_ENSGRID}" = "TRUE" ] || \
+     [ "${RUN_TASK_VX_ENSPOINT}" = "TRUE" ]; then
 
     if [ "$MACHINE" = "HERA" ]; then
       met_install_dir="/contrib/met/10.0.0"
       metplus_path="/contrib/METplus/METplus-4.0.0"
-      ccpa_obs_dir="/scratch2/BMC/det/UFS_SRW_app/v1p0/obs_data/ccpa/proc"
-      mrms_obs_dir="/scratch2/BMC/det/UFS_SRW_app/v1p0/obs_data/mrms/proc"
-      ndas_obs_dir="/scratch2/BMC/det/UFS_SRW_app/v1p0/obs_data/ndas/proc"
+      ccpa_obs_dir="/scratch2/BMC/det/UFS_SRW_app/develop/obs_data/ccpa/proc"
+      mrms_obs_dir="/scratch2/BMC/det/UFS_SRW_app/develop/obs_data/mrms/proc"
+      ndas_obs_dir="/scratch2/BMC/det/UFS_SRW_app/develop/obs_data/ndas/proc"
+    elif [ "$MACHINE" = "CHEYENNE" ]; then
+      met_install_dir="/glade/p/ral/jntp/MET/MET_releases/10.0.0"
+      metplus_path="/glade/p/ral/jntp/MET/METplus/METplus-4.0.0"
+      ccpa_obs_dir="/glade/p/ral/jntp/UFS_SRW_app/develop/obs_data/ccpa/proc"
+      mrms_obs_dir="/glade/p/ral/jntp/UFS_SRW_app/develop/obs_data/mrms/proc"
+      ndas_obs_dir="/glade/p/ral/jntp/UFS_SRW_app/develop/obs_data/ndas/proc"
     else
       print_err_msg_exit "\
 The MET and MET+ paths (MET_INSTALL_DIR and MET_INSTALL_DIR) or the observation directories

--- a/tests/WE2E/run_WE2E_tests.sh
+++ b/tests/WE2E/run_WE2E_tests.sh
@@ -950,13 +950,11 @@ external model files should be located has not been specified for this
 machine (MACHINE):
   MACHINE= \"${MACHINE}\""
     fi
-   
-    EXTRN_MDL_SOURCE_BASEDIR_ICS="${extrn_mdl_source_basedir}/${EXTRN_MDL_NAME_ICS}"
 
+    EXTRN_MDL_SOURCE_BASEDIR_ICS="${extrn_mdl_source_basedir}/${EXTRN_MDL_NAME_ICS}"
     if [ "${EXTRN_MDL_NAME_ICS}" = "FV3GFS" ] && [ "$MACHINE" = "HERA" ]; then
       EXTRN_MDL_SOURCE_BASEDIR_ICS="${EXTRN_MDL_SOURCE_BASEDIR_ICS}/${FV3GFS_FILE_FMT_ICS}"
     fi
-
     if [ "${EXTRN_MDL_NAME_ICS}" = "FV3GFS" ] || \
        [ "${EXTRN_MDL_NAME_ICS}" = "GSMGFS" ]; then
       if [ "${FV3GFS_FILE_FMT_ICS}" = "nemsio" ]; then
@@ -975,11 +973,6 @@ machine (MACHINE):
     if [ "${EXTRN_MDL_NAME_LBCS}" = "FV3GFS" ] && [ "$MACHINE" = "HERA" ]; then
       EXTRN_MDL_SOURCE_BASEDIR_LBCS="${EXTRN_MDL_SOURCE_BASEDIR_LBCS}/${FV3GFS_FILE_FMT_LBCS}"
     fi
-
-    if [ "${EXTRN_MDL_NAME_LBCS}" = "FV3GFS" ] && [ "$MACHINE" = "HERA" ]; then
-      EXTRN_MDL_SOURCE_BASEDIR_LBCS="${EXTRN_MDL_SOURCE_BASEDIR_LBCS}/${FV3GFS_FILE_FMT_LBCS}"
-    fi
-
 #
 # Make sure that the forecast length is evenly divisible by the interval
 # between the times at which the lateral boundary conditions will be


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Added ability to run verification tasks on Cheyenne by including a new modulefiles/tasks/cheyenne/run_vx.local. Also updated the WE2E test to run the MET_verification configuration on Cheyenne.

## TESTS CONDUCTED: 
On Cheyenne:
PREDEF_GRID_NAME="RRFS_CONUS_25km"
CCPP_PHYS_SUITE="FV3_GFS_v15p2"
FCST_LEN_HRS="36"
LBC_SPEC_INTVL_HRS="3"
DATE_FIRST_CYCL="20190615"
DATE_LAST_CYCL="20190615"
CYCL_HRS=( "00" )
EXTRN_MDL_NAME_ICS="FV3GFS"
EXTRN_MDL_NAME_LBCS="FV3GFS"
FV3GFS_FILE_FMT_ICS="grib2"
FV3GFS_FILE_FMT_LBCS="grib2"
MODEL="FV3_GFS_v15p2_CONUS_25km"
METPLUS_PATH="/glade/p/ral/jntp/MET/METplus/METplus-4.0.0"
MET_INSTALL_DIR="/glade/p/ral/jntp/MET/MET_releases/10.0.0"
CCPA_OBS_DIR="/glade/p/ral/jntp/UFS_SRW_app/develop/obs_data/ccpa/proc"
MRMS_OBS_DIR="/glade/p/ral/jntp/UFS_SRW_app/develop/obs_data/mrms/proc"
NDAS_OBS_DIR="/glade/p/ral/jntp/UFS_SRW_app/develop/obs_data/ndas/proc"
RUN_TASK_GET_OBS_CCPA="FALSE"
RUN_TASK_GET_OBS_MRMS="FALSE"
RUN_TASK_GET_OBS_NDAS="FALSE"
RUN_TASK_VX_GRIDSTAT="TRUE"
RUN_TASK_VX_POINTSTAT="TRUE"
USE_USER_STAGED_EXTRN_FILES="TRUE"

## DEPENDENCIES:

## DOCUMENTATION:
Documentation for running verification tasks is still in the works. Coming in the future!

## ISSUE (optional): 
I thought there was an issue created for porting the verification to Cheyenne but I cannot find it so maybe there was not!

## CONTRIBUTORS (optional): 
Used @michelleharrold WE2E script that is in her PR and updated it further to have the paths necessary for Cheyenne. These will need to be appropriately merged depending on which one goes in first.

