### PR TITLE
'EMC_post' is changed to 'UPP'

### DIFF
--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -450,7 +450,7 @@ create_symlink_to_file target="${FIELD_DICT_FP}" \
                        relative="${relative_link_flag}"
 
 if [ ${WRITE_DOPOST} = "TRUE" ]; then
-  cp_vrfy ${EMC_POST_DIR}/parm/nam_micro_lookup.dat ./eta_micro_lookup.dat
+  cp_vrfy ${UPP_DIR}/parm/nam_micro_lookup.dat ./eta_micro_lookup.dat
   if [ ${USE_CUSTOM_POST_CONFIG_FILE} = "TRUE" ]; then
     post_config_fp="${CUSTOM_POST_CONFIG_FP}"
     print_info_msg "
@@ -458,7 +458,7 @@ if [ ${WRITE_DOPOST} = "TRUE" ]; then
   CUSTOM_POST_CONFIG_FP = \"${CUSTOM_POST_CONFIG_FP}\"
 ===================================================================="
   else
-    post_config_fp="${EMC_POST_DIR}/parm/postxconfig-NT-fv3lam.txt"
+    post_config_fp="${UPP_DIR}/parm/postxconfig-NT-fv3lam.txt"
     print_info_msg "
 ====================================================================
   post_config_fp = \"${post_config_fp}\"
@@ -466,7 +466,7 @@ if [ ${WRITE_DOPOST} = "TRUE" ]; then
   fi
   cp_vrfy ${post_config_fp} ./postxconfig-NT_FH00.txt
   cp_vrfy ${post_config_fp} ./postxconfig-NT.txt
-  cp_vrfy ${EMC_POST_DIR}/parm/params_grib2_tbl_new .
+  cp_vrfy ${UPP_DIR}/parm/params_grib2_tbl_new .
 fi
 
 if [ "${DO_ENSEMBLE}" = TRUE ]; then

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -164,7 +164,7 @@ esac
 #-----------------------------------------------------------------------
 #
 rm_vrfy -f fort.*
-cp_vrfy ${EMC_POST_DIR}/parm/nam_micro_lookup.dat ./eta_micro_lookup.dat
+cp_vrfy ${UPP_DIR}/parm/nam_micro_lookup.dat ./eta_micro_lookup.dat
 if [ ${USE_CUSTOM_POST_CONFIG_FILE} = "TRUE" ]; then
   post_config_fp="${CUSTOM_POST_CONFIG_FP}"
   print_info_msg "
@@ -175,7 +175,7 @@ to the temporary work directory (tmp_dir):
   tmp_dir = \"${tmp_dir}\"
 ===================================================================="
 else
-  post_config_fp="${EMC_POST_DIR}/parm/postxconfig-NT-fv3lam.txt"
+  post_config_fp="${UPP_DIR}/parm/postxconfig-NT-fv3lam.txt"
   print_info_msg "
 ====================================================================
 Copying the default post flat file specified by post_config_fp to the 
@@ -185,7 +185,7 @@ temporary work directory (tmp_dir):
 ===================================================================="
 fi
 cp_vrfy ${post_config_fp} ./postxconfig-NT.txt
-cp_vrfy ${EMC_POST_DIR}/parm/params_grib2_tbl_new .
+cp_vrfy ${UPP_DIR}/parm/params_grib2_tbl_new .
 #
 #-----------------------------------------------------------------------
 #

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -1514,7 +1514,7 @@ DT_SUBHOURLY_POST_MNTS="00"
 # should be used for post-processing the model data. If this is set to
 # "TRUE", then the workflow will use the custom post-processing (UPP) 
 # configuration file specified in CUSTOM_POST_CONFIG_FP. Otherwise, a 
-# default configuration file provided in the EMC_post repository will be 
+# default configuration file provided in the UPP repository will be 
 # used.
 #
 # CUSTOM_POST_CONFIG_FP:

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -977,21 +977,21 @@ Please clone the external repository containing the code in this direct-
 ory, build the executables, and then rerun the workflow."
 fi
 #
-# Get the base directory of the EMC_post code.
+# Get the base directory of the UPP code.
 #
-external_name="EMC_post"
-EMC_POST_DIR=$( \
+external_name="UPP"
+UPP_DIR=$( \
 get_manage_externals_config_property \
 "${mng_extrns_cfg_fn}" "${external_name}" "${property_name}" ) || \
 print_err_msg_exit "\
 Call to function get_manage_externals_config_property failed."
 
-EMC_POST_DIR="${SR_WX_APP_TOP_DIR}/${EMC_POST_DIR}"
-if [ ! -d "${EMC_POST_DIR}" ]; then
+UPP_DIR="${SR_WX_APP_TOP_DIR}/${UPP_DIR}"
+if [ ! -d "${UPP_DIR}" ]; then
   print_err_msg_exit "\
-The base directory in which the EMC_post source code should be located
-(EMC_POST_DIR) does not exist:
-  EMS_POST_DIR = \"${EMC_POST_DIR}\"
+The base directory in which the UPP source code should be located
+(UPP_DIR) does not exist:
+  UPP_DIR = \"${UPP_DIR}\"
 Please clone the external repository containing the code in this directory,
 build the executable, and then rerun the workflow."
 fi
@@ -2682,7 +2682,7 @@ UFS_WTHR_MDL_DIR="${UFS_WTHR_MDL_DIR}"
 UFS_UTILS_DIR="${UFS_UTILS_DIR}"
 SFC_CLIMO_INPUT_DIR="${SFC_CLIMO_INPUT_DIR}"
 TOPO_DIR="${TOPO_DIR}"
-EMC_POST_DIR="${EMC_POST_DIR}"
+UPP_DIR="${UPP_DIR}"
 
 EXPTDIR="$EXPTDIR"
 LOGDIR="$LOGDIR"


### PR DESCRIPTION

## DESCRIPTION OF CHANGES: 
Since the repository name of post-processing was changed from 'EMC_post' to 'UPP', the external name and prefix for post-processing is changed from 'EMC_post' to 'UPP'.


## TESTS CONDUCTED: 
WE2E tests on WCOSS_DELL_P3:
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- MET_verification


## DEPENDENCIES:
- https://github.com/ufs-community/ufs-srweather-app/pull/171


## ISSUE: 
Fixes issue mentioned in #589 
