### PR TITLE
Remove unbound variables from run_WE2E_tests.sh

### DIFF
--- a/tests/WE2E/run_WE2E_tests.sh
+++ b/tests/WE2E/run_WE2E_tests.sh
@@ -1023,9 +1023,7 @@ EXTRN_MDL_FILES_LBCS=( $( printf "\"%s\" " "${EXTRN_MDL_FILES_LBCS[@]}" ))"
 #-----------------------------------------------------------------------
 #
   if [ "${RUN_TASK_VX_GRIDSTAT}" = "TRUE" ] || \
-     [ "${RUN_TASK_VX_POINTSTAT}" = "TRUE" ] || \
-     [ "${RUN_TASK_VX_ENSGRID}" = "TRUE" ] || \
-     [ "${RUN_TASK_VX_ENSPOINT}" = "TRUE" ]; then
+     [ "${RUN_TASK_VX_POINTSTAT}" = "TRUE" ]; then
 
     if [ "$MACHINE" = "WCOSS_CRAY" ]; then
       met_install_dir="/gpfs/hps/nco/ops/nwprod/met.v9.1.3"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The WE2E tests fail due to the undeclared variables 'RUN_TASK_VX_ENSGRID' and 'RUN_TASK_VX_ENSPOINT' in 'run_WE2E_tests.sh'. Since these two variables are not used in the regional workflow yet, they are removed from the script.

## TESTS CONDUCTED: 
WE2E test:
- MET_verification

## ISSUE: 
Fixes issue mentioned in #591 


