### PR TITLE
Update MET/METplus in WE2E for WCOSS Cray

### DIFF
--- a/modulefiles/tasks/wcoss_cray/run_vx.local
+++ b/modulefiles/tasks/wcoss_cray/run_vx.local
@@ -9,5 +9,5 @@ module load udreg
 module load ugni
 module load xpmem
 
-module use /gpfs/hps/nco/ops/nwprod/modulefiles
-module load met/9.1.3
+module use /gpfs/hps3/emc/meso/noscrub/emc.metplus/modulefiles
+module load met/10.0.0

--- a/tests/WE2E/run_WE2E_tests.sh
+++ b/tests/WE2E/run_WE2E_tests.sh
@@ -1026,8 +1026,8 @@ EXTRN_MDL_FILES_LBCS=( $( printf "\"%s\" " "${EXTRN_MDL_FILES_LBCS[@]}" ))"
      [ "${RUN_TASK_VX_POINTSTAT}" = "TRUE" ]; then
 
     if [ "$MACHINE" = "WCOSS_CRAY" ]; then
-      met_install_dir="/gpfs/hps/nco/ops/nwprod/met.v9.1.3"
-      metplus_path="/gpfs/hps/nco/ops/nwprod/metplus.v3.1.1/METplus-3.1.1"
+      met_install_dir="/gpfs/hps3/emc/meso/noscrub/emc.metplus/met/10.0.0"
+      metplus_path="/gpfs/hps3/emc/meso/noscrub/emc.metplus/METplus/METplus-4.0.0"
       ccpa_obs_dir="/gpfs/hps3/emc/meso/noscrub/UFS_SRW_App/obs_data/ccpa/proc"
       mrms_obs_dir="/gpfs/hps3/emc/meso/noscrub/UFS_SRW_App/obs_data/mrms/proc"
       ndas_obs_dir="/gpfs/hps3/emc/meso/noscrub/UFS_SRW_App/obs_data/ndas/proc"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The version of MET/METplus in the WE2E script is updated to the latest for the WCOSS Cray.

## TESTS CONDUCTED: 
WE2E 'MET_verification' test on the WCOSS Cray

## ISSUE: 
Fixes issue mentioned in #594 


