### PR TITLE
Add necessary namelist entries to activate GSL GWD when using the FV3_HRRR SDF

### DIFF
--- a/ush/templates/FV3.input.yml
+++ b/ush/templates/FV3.input.yml
@@ -70,6 +70,9 @@ FV3_HRRR:
     do_mynnsfclay: True
     do_sfcperts: !!python/none
     gwd_opt: 3
+    do_gsl_drag_ss: True
+    do_gsl_drag_tofd: True
+    do_gsl_drag_ls_bl: True 
     iaer: 5111
     icliq_sw: 2
     imfdeepcnv: -1


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The following entries were added to the namelist YAML file to activate GSL GWD when running with the FV3_HRRR SDF:

```
    do_gsl_drag_ss=.true.
    do_gsl_drag_tofd=.true.
    do_gsl_drag_ls_bl=.true.
```

Without these flags, the GSL GWD scheme is not correctly activated. 

## TESTS CONDUCTED: 
Tested with the RRFS_CONUS_25km domain on Hera.

## ISSUE (optional): 
Fixes Issue #596. 

## CONTRIBUTORS (optional): 
@llpcarson

