### PR TITLE
Adding an environment file for installing pygraf.

### DIFF
--- a/ush/Python/environment.yml
+++ b/ush/Python/environment.yml
@@ -1,0 +1,15 @@
+name: pygraf
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.7*
+  - basemap=1.2*
+  - basemap-data-hires=1.2.1
+  - pynio=1.5.5
+  - matplotlib=3.2*
+  - metpy=0.12.1
+  - pylint=2.4*
+  - pytest=6.1*
+  - pyyaml=5.3.1
+  - xarray=0.15.1


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This addition should allow a user to install their own pygraf conda environment for platforms that are not supported. It is identical (currently) to the one included in the https://github.com/NOAA-GSL/pygraf repo.

## TESTS CONDUCTED: 
It is used regularly in our CI/CD tests.

## DOCUMENTATION:
I am unsure where/if this type of activity is included in the docs. I'd be happy to add a few lines on this file if someone could point me to the best place for it.


