### PR TITLE
Fix unbound SED for cron commands in the launch script

### DIFF
--- a/ush/launch_FV3LAM_wflow.sh
+++ b/ush/launch_FV3LAM_wflow.sh
@@ -405,7 +405,7 @@ launch script for this experiment:
 # CRONTAB_LINE with backslashes.  Do this next.
 #
     crontab_line_esc_astr=$( printf "%s" "${CRONTAB_LINE}" | \
-                             $SED -r -e "s%[*]%\\\\*%g" )
+                             sed -r -e "s%[*]%\\\\*%g" )
 #
 # In the string passed to the grep command below, we use the line start
 # and line end anchors ("^" and "$", respectively) to ensure that we on-


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
To fix the issue on the launch script when 'USE_CRON_TO_RELAUNCH'="TRUE", '$SED' is modified to 'sed' in the script.

## TESTS CONDUCTED: 
WE2E tests on WCOSS_DELL_P3:
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- MET_ensemble_verification

## ISSUE: 
Fixes issue mentioned in #605 
