### PR TITLE
Add ulimit to the task scripts for Orion

### DIFF
--- a/scripts/exregional_make_grid.sh
+++ b/scripts/exregional_make_grid.sh
@@ -107,10 +107,14 @@ case "$MACHINE" in
     ;;
 
   "HERA")
+    ulimit -s unlimited
+    ulimit -a
     APRUN="time"
     ;;
 
   "ORION")
+    ulimit -s unlimited
+    ulimit -a
     APRUN="time"
     ;;
 

--- a/scripts/exregional_make_grid.sh
+++ b/scripts/exregional_make_grid.sh
@@ -107,8 +107,6 @@ case "$MACHINE" in
     ;;
 
   "HERA")
-    ulimit -s unlimited
-    ulimit -a
     APRUN="time"
     ;;
 

--- a/scripts/exregional_make_ics.sh
+++ b/scripts/exregional_make_ics.sh
@@ -105,6 +105,7 @@ case "$MACHINE" in
 
   "ORION")
     ulimit -s unlimited
+    ulimit -a
     APRUN="srun"
     ;;
 

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -125,6 +125,8 @@ case "$MACHINE" in
     ;;
 
   "ORION")
+    ulimit -s unlimited
+    ulimit -a
     APRUN="srun"
     ;;
 

--- a/tests/WE2E/test_configs/grids_extrn_mdls_suites_community/config.grid_RRFS_NA_3km_ics_FV3GFS_lbcs_FV3GFS_suite_RRFS_v1alpha.sh
+++ b/tests/WE2E/test_configs/grids_extrn_mdls_suites_community/config.grid_RRFS_NA_3km_ics_FV3GFS_lbcs_FV3GFS_suite_RRFS_v1alpha.sh
@@ -48,6 +48,7 @@ WTIME_MAKE_LBCS="01:00:00"
 NNODES_RUN_POST="6"
 PPN_RUN_POST="12"
 
+OMP_STACKSIZE_MAKE_ICS="2048m"
 OMP_STACKSIZE_RUN_FCST="2048m"
 
 ###############################################################################


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
To resolve the memory issue, 'ulimit' is added to the 'make_grid', 'make_ics', and 'run_post' scripts for Orion.

## TESTS CONDUCTED: 
WE2E tests on Orion and Hera:
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_NA_3km_ics_FV3GFS_lbcs_FV3GFS_suite_RRFS_v1alpha

## ISSUE: 
Fixes issue mentioned in #625 

