### PR TITLE
Move rocoto commands for WCOSS from launch script to env files

### DIFF
--- a/ush/launch_FV3LAM_wflow.sh
+++ b/ush/launch_FV3LAM_wflow.sh
@@ -106,26 +106,14 @@ expt_name="${EXPT_SUBDIR}"
 #
 #-----------------------------------------------------------------------
 #
-if [ "$MACHINE" = "WCOSS_DELL_P3" ]; then
-  module purge
-  module load lsf/10.1
-  module use /gpfs/dell3/usrx/local/dev/emc_rocoto/modulefiles/
-  module load ruby/2.5.1 rocoto/1.3.0rc2
-elif [ "$MACHINE" = "WCOSS_CRAY" ]; then
-  module purge
-  module load xt-lsfhpc/9.1.3
-  module use -a /usrx/local/emc_rocoto/modulefiles
-  module load rocoto/1.3.0rc2
-else
-  machine=$(echo_lowercase $MACHINE)
-  env_fn=${WFLOW_ENV_FN:-"wflow_${machine}.env"}
-  env_fp="${SR_WX_APP_TOP_DIR}/env/${env_fn}"
-  module purge
-  source "${env_fp}" || print_err_msg_exit "\
-    Sourcing platform-specific environment file (env_fp) for
-  the workflow task failed :
-      env_fp = \"${env_fp}\""
-fi
+machine=$(echo_lowercase $MACHINE)
+env_fn=${WFLOW_ENV_FN:-"wflow_${machine}.env"}
+env_fp="${SR_WX_APP_TOP_DIR}/env/${env_fn}"
+module purge
+source "${env_fp}" || print_err_msg_exit "\
+  Sourcing platform-specific environment file (env_fp) for
+the workflow task failed :
+env_fp = \"${env_fp}\""
 #
 #-----------------------------------------------------------------------
 #


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The rocoto commands for the WCOSS dell and cray move from the launch script to the workflow environment files in the UFS SRW App like other machines.

## TESTS CONDUCTED: 
WE2E tests on the WCOSS dell and cray:
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- nco_grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- MET_ensemble_verification

## DEPENDENCIES:
- https://github.com/ufs-community/ufs-srweather-app/pull/191

## ISSUE: 
Fixes issue mentioned in #635 

