### PR TITLE
Rename unchanged readlink in task scripts for verification

### DIFF
--- a/scripts/exregional_run_ensgridvx.sh
+++ b/scripts/exregional_run_ensgridvx.sh
@@ -28,7 +28,7 @@ set -x
 #
 #-----------------------------------------------------------------------
 #
-scrfunc_fp=$( readlink -f "${BASH_SOURCE[0]}" )
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
 scrfunc_fn=$( basename "${scrfunc_fp}" )
 scrfunc_dir=$( dirname "${scrfunc_fp}" )
 #

--- a/scripts/exregional_run_ensgridvx_mean.sh
+++ b/scripts/exregional_run_ensgridvx_mean.sh
@@ -28,7 +28,7 @@ set -x
 #
 #-----------------------------------------------------------------------
 #
-scrfunc_fp=$( readlink -f "${BASH_SOURCE[0]}" )
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
 scrfunc_fn=$( basename "${scrfunc_fp}" )
 scrfunc_dir=$( dirname "${scrfunc_fp}" )
 #

--- a/scripts/exregional_run_ensgridvx_prob.sh
+++ b/scripts/exregional_run_ensgridvx_prob.sh
@@ -28,7 +28,7 @@ set -x
 #
 #-----------------------------------------------------------------------
 #
-scrfunc_fp=$( readlink -f "${BASH_SOURCE[0]}" )
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
 scrfunc_fn=$( basename "${scrfunc_fp}" )
 scrfunc_dir=$( dirname "${scrfunc_fp}" )
 #

--- a/scripts/exregional_run_enspointvx.sh
+++ b/scripts/exregional_run_enspointvx.sh
@@ -28,7 +28,7 @@ set -x
 #
 #-----------------------------------------------------------------------
 #
-scrfunc_fp=$( readlink -f "${BASH_SOURCE[0]}" )
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
 scrfunc_fn=$( basename "${scrfunc_fp}" )
 scrfunc_dir=$( dirname "${scrfunc_fp}" )
 #

--- a/scripts/exregional_run_enspointvx_mean.sh
+++ b/scripts/exregional_run_enspointvx_mean.sh
@@ -28,7 +28,7 @@ set -x
 #
 #-----------------------------------------------------------------------
 #
-scrfunc_fp=$( readlink -f "${BASH_SOURCE[0]}" )
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
 scrfunc_fn=$( basename "${scrfunc_fp}" )
 scrfunc_dir=$( dirname "${scrfunc_fp}" )
 #

--- a/scripts/exregional_run_enspointvx_prob.sh
+++ b/scripts/exregional_run_enspointvx_prob.sh
@@ -28,7 +28,7 @@ set -x
 #
 #-----------------------------------------------------------------------
 #
-scrfunc_fp=$( readlink -f "${BASH_SOURCE[0]}" )
+scrfunc_fp=$( $READLINK -f "${BASH_SOURCE[0]}" )
 scrfunc_fn=$( basename "${scrfunc_fp}" )
 scrfunc_dir=$( dirname "${scrfunc_fp}" )
 #


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
The unchanged 'readlink' are renamed to "$READLINK" in the multiple task scripts for verification.

## TESTS CONDUCTED: 
WE2E tests on the wcoss dell:
- MET_verification
- MET_ensemble_verification

## ISSUE: 
Fixes issue mentioned in #637 

