### PR TITLE
Update template namelist files for newer ufs weather model

### DIFF
--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -234,8 +234,8 @@ tmmark="tm00"
 # minutes and seconds of the corresponding output forecast time.
 #
 # Note that if the forecast model is instructed to output at some hourly
-# interval (via the nfhout and nfhout_hf parameters in the MODEL_CONFIG_FN
-# file, with nsout set to a non-positive value), then the write-component
+# interval (via the output_fh parameter in the MODEL_CONFIG_FN file, 
+# with nsout set to a non-positive value), then the write-component
 # output file names will not contain any suffix for the minutes and seconds.
 # For this reason, when SUB_HOURLY_POST is not set to "TRUE", mnts_sec_str
 # must be set to a null string.

--- a/ush/create_model_configure_file.sh
+++ b/ush/create_model_configure_file.sh
@@ -114,6 +114,7 @@ run directory (run_dir):
 #
   settings="\
   'PE_MEMBER01': ${PE_MEMBER01}
+  'print_esmf': ${dot_print_esmf_dot}
   'start_year': $yyyy
   'start_month': $mm
   'start_day': $dd
@@ -125,7 +126,6 @@ run directory (run_dir):
   'restart_interval': ${RESTART_INTERVAL}
   'write_dopost': ${dot_write_dopost}
   'quilting': ${dot_quilting_dot}
-  'print_esmf': ${dot_print_esmf_dot}
   'output_grid': ${WRTCMP_output_grid}"
 #  'output_grid': \'${WRTCMP_output_grid}\'"
 #
@@ -185,17 +185,15 @@ run directory (run_dir):
 # main time step dt_atmos (in units of seconds).  Note that nsout is 
 # guaranteed to be an integer because the experiment generation scripts 
 # require that dt_subhourly_post_mnts (after conversion to seconds) be 
-# evenly divisible by dt_atmos.  Also, in this case, the variable nfhout 
-# [which specifies the (low-frequency) output interval in hours after 
-# forecast hour nfhmax_hf; see the jinja model_config template file] is 
-# set to 0, although this doesn't matter because any positive of nsout 
-# will override nfhout.
+# evenly divisible by dt_atmos.  Also, in this case, the variable output_fh 
+# [which specifies the output interval in hours; 
+# see the jinja model_config template file] is set to 0, although this 
+# doesn't matter because any positive of nsout will override output_fh.
 #
 # If sub_hourly_post is set to "FALSE", then the workflow is hard-coded 
 # (in the jinja model_config template file) to direct the forecast model 
-# to output files every hour.  This is done by setting (1) nfhout_hf to 
-# 1 in that jinja template file, (2) nfhout to 1 here, and (3) nsout to
-# -1 here which turns off output by time step interval.
+# to output files every hour.  This is done by setting (1) output_fh to 1 
+# here, and (2) nsout to -1 here which turns off output by time step interval.
 #
 # Note that the approach used here of separating how hourly and subhourly
 # output is handled should be changed/generalized/simplified such that 
@@ -208,13 +206,13 @@ run directory (run_dir):
 #
   if [ "${sub_hourly_post}" = "TRUE" ]; then
     nsout=$(( dt_subhourly_post_mnts*60 / dt_atmos ))
-    nfhout=0
+    output_fh=0
   else
-    nfhout=1
+    output_fh=1
     nsout=-1
   fi
   settings="${settings}
-  'nfhout': ${nfhout}
+  'output_fh': ${output_fh}
   'nsout': ${nsout}"
 
   print_info_msg $VERBOSE "

--- a/ush/templates/FV3.input.yml
+++ b/ush/templates/FV3.input.yml
@@ -288,11 +288,6 @@ FV3_GFS_v15p2:
   surf_map_nml:
 
 FV3_GFS_v16:
-  atmos_model_nml:
-    fhmax: 240
-    fhmaxhf: 0
-    fhout: 3
-    fhouthf: 1
   cires_ugwp_nml:
     launch_level: 27
   fv_core_nml:

--- a/ush/templates/input.nml.FV3
+++ b/ush/templates/input.nml.FV3
@@ -70,6 +70,7 @@
     do_schmidt = .true.
     do_vort_damp = .true.
     dwind_2d = .false.
+    dz_min = 2
     external_eta = .true.
     external_ic = .true.
     fill = .true.
@@ -108,6 +109,7 @@
     p_fac = 0.1
     phys_hydrostatic = .false.
     print_freq = 6
+    psm_bc = 1
     range_warn = .true.
     read_increment = .false.
     regional = .true.
@@ -180,6 +182,7 @@
     oz_phys_2015 = .true.
     pdfcld = .false.
     pre_rad = .false.
+    print_diff_pgr = .false.
     prslrd0 = 0.0
     random_clds = .false.
     redrag = .true.

--- a/ush/templates/input.nml.FV3
+++ b/ush/templates/input.nml.FV3
@@ -10,7 +10,6 @@
 &atmos_model_nml
     chksum_debug = .false.
     dycore_only = .false.
-    fdiag = 1
 /
 
 &cires_ugwp_nml
@@ -174,7 +173,6 @@
     ltaerosol = .true.
     lwhtr = .true.
     n_var_lndp = 0
-    ncld = 5
     nsradar_reset = 3600
     nst_anl = .true.
     nstf_name = 2,1,0,0,0

--- a/ush/templates/model_configure
+++ b/ush/templates/model_configure
@@ -1,5 +1,4 @@
-total_member:            1
-PE_MEMBER01:             {{ PE_MEMBER01 }}
+print_esmf:              {{ print_esmf }}
 start_year:              {{ start_year }}
 start_month:             {{ start_month }}
 start_day:               {{ start_day }}
@@ -7,18 +6,12 @@ start_hour:              {{ start_hour }}
 start_minute:            0
 start_second:            0
 nhours_fcst:             {{ nhours_fcst }}
-RUN_CONTINUE:            .false.
-ENS_SPS:                 .false.
+
 dt_atmos:                {{ dt_atmos }}
 cpl:                     {{ cpl }}
 calendar:                'julian'
-memuse_verbose:          .false.
-atmos_nthreads:          {{ atmos_nthreads }}
-use_hyper_thread:        .false.
-debug_affinity:          .true.
 restart_interval:        {{ restart_interval }}
 output_1st_tstep_rst:    .false.
-print_esmf:              {{ print_esmf }}
 write_dopost:            {{ write_dopost }}
 quilting:                {{ quilting }}
 
@@ -29,29 +22,26 @@ quilting:                {{ quilting }}
 write_groups:            {{ write_groups }}
 write_tasks_per_group:   {{ write_tasks_per_group }}
 num_files:               2
-filename_base:           'dyn''phy'
-output_file:             'netcdf'
-write_nemsioflip:        .false.
-write_fsyncflag:         .false.
+filename_base:           'dyn' 'phy'
+output_file:             'netcdf' 'netcdf'
+ideflate:                0
+nbits:                   0
+ichunk2d:                -1
+jchunk2d:                -1
+ichunk3d:                -1
+jchunk3d:                -1
+kchunk3d:                -1
 #
 # Write-component output frequency parameter definitions:
 #
-# nfhout:
-# Output frequency in hours after forecast hour "nfhmax_hf".
-#
-# nfhmax_hf:
-# Number of forecast hours until output frequency "nfhout" takes affect.
-#
-# nfhout_hf:
-# Output frequency in hours until forecast hour "nfhmax_hf".
+# output_fh:
+# Output frequency in hours.
 #
 # nsout:
 # Output frequency in time steps (positive values override "nfhout" and 
 # "nfhout_hf").
 #
-nfhout:     {{ nfhout }}
-nfhmax_hf:  60
-nfhout_hf:  1
+output_fh:  {{ nfhout }}  -1
 nsout:      {{ nsout }}
 #
 # Coordinate system used by the output grid.

--- a/ush/templates/model_configure
+++ b/ush/templates/model_configure
@@ -26,11 +26,6 @@ filename_base:           'dyn' 'phy'
 output_file:             'netcdf' 'netcdf'
 ideflate:                0
 nbits:                   0
-ichunk2d:                -1
-jchunk2d:                -1
-ichunk3d:                -1
-jchunk3d:                -1
-kchunk3d:                -1
 #
 # Write-component output frequency parameter definitions:
 #

--- a/ush/templates/model_configure
+++ b/ush/templates/model_configure
@@ -18,9 +18,9 @@ atmos_nthreads:          {{ atmos_nthreads }}
 restart_interval:        {{ restart_interval }}
 output_1st_tstep_rst:    .false.
 write_dopost:            {{ write_dopost }}
-quilting:                {{ quilting }}
 ideflate:                0
 nbits:                   0
+quilting:                {{ quilting }}
 {% if quilting  %}
 #
 # Write-component (quilting) computational parameters.
@@ -33,14 +33,10 @@ output_file:             'netcdf' 'netcdf'
 #
 # Write-component output frequency parameter definitions:
 #
-# output_fh:
-# Output frequency in hours.
+# output_fh: Output frequency in hours.
+# nsout: Output frequency in time steps (positive values override "output_fh").
 #
-# nsout:
-# Output frequency in time steps (positive values override "nfhout" and 
-# "nfhout_hf").
-#
-output_fh:  {{ nfhout }}  -1
+output_fh:  {{ output_fh }}  -1
 nsout:      {{ nsout }}
 #
 # Coordinate system used by the output grid.
@@ -50,97 +46,48 @@ output_grid:  '{{ output_grid }}'
 # Parameter definitions for an output grid of type "{{ output_grid }}":
 #
   {%- if output_grid == "lambert_conformal" %}
-# cen_lon:
-# Longitude of center of grid (degrees).
-#
-# cen_lat:
-# Latitude of center of grid (degrees).
-#
-# stdlat1:
-# Latitude of first standard parallel (degrees).
-#
-# stdlat2:
-# Latitude of second standard parallel (degrees).
-#
-# nx:
-# Number of grid cells along x-axis in Lambert conformal (x,y) plane.
-#
-# ny:
-# Number of grid cells along y-axis in Lambert conformal (x,y) plane.
-#
-# lon1:
-# Longitude of center of grid cell at bottom-left corner of grid (degrees).
-#
-# lat1:
-# Latitude of center of grid cell at bottom-left corner of grid (degrees).
-#
-# dx:
-# Grid cell size in x direction (meters).
-#
-# dy:
-# Grid cell size in y direction (meters).
+# cen_lon: Longitude of center of grid (degrees).
+# cen_lat: Latitude of center of grid (degrees).
+# stdlat1: Latitude of first standard parallel (degrees).
+# stdlat2: Latitude of second standard parallel (degrees).
+# nx: Number of grid cells along x-axis in Lambert conformal (x,y) plane.
+# ny: Number of grid cells along y-axis in Lambert conformal (x,y) plane.
+# lon1: Longitude of center of grid cell at bottom-left corner of grid (degrees).
+# lat1: Latitude of center of grid cell at bottom-left corner of grid (degrees).
+# dx: Grid cell size in x direction (meters).
+# dy: Grid cell size in y direction (meters).
 #
   {%- elif output_grid == "regional_latlon" %}
-# cen_lon:
-# Longitude of center of grid (degrees).
-#
-# cen_lat:
-# Latitude of center of grid (degrees).
-#
-# lon1:
-# Longitude of center of lower-left (southwest) grid cell (degrees).
-#
-# lat1:
-# Latitude of center of lower-left (southwest) grid cell (degrees).
-#
-# lon2:
-# Longitude of center of upper-right (northeast) grid cell (degrees).
-#
-# lat2:
-# Latitude of center of upper-right (northeast) grid cell (degrees).
-#
-# dlon:
-# Longitudinal grid size (degrees).
-#
-# dlat:
-# Latitudinal grid size (degrees).
+# cen_lon: Longitude of center of grid (degrees).
+# cen_lat: Latitude of center of grid (degrees).
+# lon1: Longitude of center of lower-left (southwest) grid cell (degrees).
+# lat1: Latitude of center of lower-left (southwest) grid cell (degrees).
+# lon2: Longitude of center of upper-right (northeast) grid cell (degrees).
+# lat2: Latitude of center of upper-right (northeast) grid cell (degrees).
+# dlon: Longitudinal grid size (degrees).
+# dlat: Latitudinal grid size (degrees).
 #
   {%- elif output_grid == "rotated_latlon" %}
-# cen_lon:
-# Longitude of center of grid, expressed in the NON-ROTATED latlon
-# coordinate system (degrees).  This is also the longitude of the point 
-# at which the equator and prime meridian of the ROTATED coordinate 
-# system intersect (i.e. the point at which the longitude and latitude 
-# in the ROTATED latlon coordinate system are both 0).
-#
-# cen_lat:
-# Latitude of center of grid, expressed in the NON-ROTATED latlon 
-# coordinate system (degrees).  This is also the latitude of the point 
-# at which the equator and prime meridian of the ROTATED coordinate system 
-# intersect (i.e. the point at which the longitude and latitude in the 
-# ROTATED latlon coordinate system are both 0).
-#
-# lon1:
-# Longitude of center of lower-left grid cell, expressed in the ROTATED 
-# latlon coordinate system (degrees).
-#
-# lat1:
-# Latitude of center of lower-left grid cell, expressed in the ROTATED 
-# latlon coordinate system (degrees).
-#
-# lon2:
-# Longitude of center of upper-right grid cell, expressed in the ROTATED 
-# latlon coordinate system (degrees).
-#
-# lat2:
-# Latitude of center of upper-right grid cell, expressed in the ROTATED 
-# latlon coordinate system (degrees).
-#
-# dlon:
-# Longitudinal grid size in the ROTATED latlon coordinate system (degrees).
-#
-# dlat:
-# Latitudinal grid size in the ROTATED latlon coordinate system (degrees).
+# cen_lon: Longitude of center of grid, expressed in the NON-ROTATED latlon coordinate 
+#          system (degrees).  This is also the longitude of the point at which the 
+#          equator and prime meridian of the ROTATED coordinate system intersect (i.e. 
+#          the point at which the longitude and latitude in the ROTATED latlon 
+#          coordinate system are both 0).
+# cen_lat: Latitude of center of grid, expressed in the NON-ROTATED latlon coordinate 
+#          system (degrees).  This is also the latitude of the point at which the 
+#          equator and prime meridian of the ROTATED coordinate system intersect (i.e. 
+#          the point at which the longitude and latitude in the ROTATED latlon 
+#          coordinate system are both 0).
+# lon1: Longitude of center of lower-left grid cell, expressed in the ROTATED latlon 
+#       coordinate system (degrees).
+# lat1: Latitude of center of lower-left grid cell, expressed in the ROTATED latlon 
+#       coordinate system (degrees).
+# lon2: Longitude of center of upper-right grid cell, expressed in the ROTATED latlon 
+#       coordinate system (degrees).
+# lat2: Latitude of center of upper-right grid cell, expressed in the ROTATED latlon 
+#       coordinate system (degrees).
+# dlon: Longitudinal grid size in the ROTATED latlon coordinate system (degrees).
+# dlat: Latitudinal grid size in the ROTATED latlon coordinate system (degrees).
 #
   {%- endif %}
   {%- if output_grid == "lambert_conformal" %}

--- a/ush/templates/model_configure
+++ b/ush/templates/model_configure
@@ -1,3 +1,5 @@
+total_member:            1
+PE_MEMBER01:             {{ PE_MEMBER01 }}
 print_esmf:              {{ print_esmf }}
 start_year:              {{ start_year }}
 start_month:             {{ start_month }}
@@ -6,15 +8,19 @@ start_hour:              {{ start_hour }}
 start_minute:            0
 start_second:            0
 nhours_fcst:             {{ nhours_fcst }}
-
+RUN_CONTINUE:            .false.
+ENS_SPS:                 .false.
 dt_atmos:                {{ dt_atmos }}
 cpl:                     {{ cpl }}
 calendar:                'julian'
+memuse_verbose:          .false.
+atmos_nthreads:          {{ atmos_nthreads }}
 restart_interval:        {{ restart_interval }}
 output_1st_tstep_rst:    .false.
 write_dopost:            {{ write_dopost }}
 quilting:                {{ quilting }}
-
+ideflate:                0
+nbits:                   0
 {% if quilting  %}
 #
 # Write-component (quilting) computational parameters.
@@ -24,8 +30,6 @@ write_tasks_per_group:   {{ write_tasks_per_group }}
 num_files:               2
 filename_base:           'dyn' 'phy'
 output_file:             'netcdf' 'netcdf'
-ideflate:                0
-nbits:                   0
 #
 # Write-component output frequency parameter definitions:
 #


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- The template namelist files, 'input.nml' and 'model_configure', are updated for use of a newer version of the UFS Weather Model.
- The namelist parameter, print_diff_pgr, for the pressure tendency diagnostic is added to 'input.nml' (default = .false.).

## TESTS CONDUCTED: 
WE2E tests on WCOSS dell and Hera:
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_13km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15p2
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16
- grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GSD_SAR
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16

## DEPENDENCIES:
- ufs-community/ufs-srweather-app/pull/193

## ISSUE: 
Fixes issue mentioned in #641 

## CONTRIBUTORS: 
@BenjaminBlake-NOAA, @MatthewPyle-NOAA
