### PR TITLE
Specify the number of tasks for run_fcst on Orion

### DIFF
--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -127,7 +127,7 @@ case "$MACHINE" in
   "ORION")
     ulimit -s unlimited
     ulimit -a
-    APRUN="srun"
+    APRUN="srun -n ${PE_MEMBER01}"
     ;;
 
   "JET")


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
To avoid job failure, the number of tasks for the 'run_fcst' task is specified (with -n) on Orion.

## TESTS CONDUCTED: 
WE2E test on Orion:
- grid_RRFS_CONUS_3km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v15_thompson_mynn_lam3km

## ISSUE: 
Fixes issue mentioned in #647 

## CONTRIBUTORS: 
@JamesAbeles-NOAA