### PR TITLE
Fix APRUN issue on WCOSS cray

### DIFF
--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -108,7 +108,7 @@ case "$MACHINE" in
     if [ ${PE_MEMBER01} -gt 24 ];then
       APRUN="aprun -b -j1 -n${PE_MEMBER01} -N24 -d1 -cc depth"
     else
-      APRUN="aprun -b -j1 -n24 -N24 -d1 -cc depth"
+      APRUN="aprun -b -j1 -n${PE_MEMBER01} -N${PE_MEMBER01} -d1 -cc depth"
     fi
     ;;
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
To avoid the failure of the 'run_fcst' task, the number of -N is set to PE_MEMBER01 in case of PE_MEMBER01<=24.

## TESTS CONDUCTED: 
GST test on the WCOSS cray

## ISSUE: 
Fixes issue mentioned in #654.
