### PR TITLE
Add stand-alone Python data ingest tool.

### DIFF
--- a/ush/retrieve_data.py
+++ b/ush/retrieve_data.py
@@ -86,6 +86,11 @@ def download_requested_files(cla, data_store, store_specs):
                     if unavailable.get(data_store) is None:
                         unavailable[data_store] = []
                     unavailable[data_store].append(target_path)
+                    os.chdir(orig_path)
+                    # Returning here assumes that if the first file
+                    # isn't found, none of the others will be. Don't
+                    # waste time timing out on every requested file.
+                    return unavailable
     os.chdir(orig_path)
     return unavailable
 

--- a/ush/retrieve_data.py
+++ b/ush/retrieve_data.py
@@ -20,6 +20,33 @@ import subprocess
 import yaml
 
 
+def copy_file(source, destination):
+
+    '''
+    Copy a file from a source and place it in the destination location.
+    Return a boolean value reflecting the state of the copy.
+
+    Assumes destination exists.
+    '''
+
+    if not os.path.exists(source):
+        logging.info(f'File does not exist on disk \n {source}')
+        return False
+
+    # Using subprocess here because system copy is much faster than
+    # python copy options.
+    cmd = f'cp {source} {destination}'
+    logging.info(f'Running command: \n {cmd}')
+    try:
+        output = subprocess.run(cmd,
+                                check=True,
+                                shell=True,
+                                )
+    except subprocess.CalledProcessError as err:
+        logging.info(err)
+        return False
+    return True
+
 def download_file(url):
 
     '''
@@ -27,8 +54,6 @@ def download_file(url):
     on disk.
 
     Arguments:
-      target_path  full path to a location on disk where file will be
-                   stored
       url          url to file to be downloaded
 
     Return:
@@ -164,6 +189,69 @@ def fill_template(template_str, cycle_date, fcst_hr=0):
         yyyymmddhh=cycle_date.strftime('%Y%m%d%H'),
         )
 
+def get_requested_files(cla, file_names, input_locs, method='disk'):
+
+    ''' This function copies files from disk locations
+    or downloads files from a url, depending on the option specified for
+    user.
+
+    This function expects that the output directory exists and is
+    writeable.
+
+    Arguments:
+
+    cla        Namespace object containing command line arguments
+    file_names Dict of file names by file type and kind
+    input_locs List of potential data locations, either urls or disk
+               paths.
+    method     Choice of disk or download to indicate protocol for
+               retrieval
+
+    Returns
+    unavailable  a dict whose keys are "method" and whose values are a
+                 list of files unretrievable
+    '''
+
+    unavailable = {}
+
+    if cla.file_type is not None:
+        file_names = file_names[cla.file_type]
+    file_names = file_names[cla.anl_or_fcst]
+
+    file_names = file_names if isinstance(file_names, list) else \
+            [file_names]
+    target_path = fill_template(cla.output_path,
+                                cla.cycle_date)
+
+    logging.info(f'Retrieved files will be placed here: \n {target_path}')
+    orig_path = os.getcwd()
+    os.chdir(target_path)
+    unavailable = {}
+    for input_loc in input_locs:
+        for fcst_hr in cla.fcst_hrs:
+            for file_name in file_names:
+                loc = os.path.join(input_loc, file_name)
+                loc = fill_template(loc, cla.cycle_date, fcst_hr)
+
+                if method == 'disk':
+                    retrieved = copy_file(loc, target_path)
+  
+                if method == 'download':
+                    retrieved = download_file(loc)
+
+                if not retrieved:
+
+                    if unavailable.get(method) is None:
+                        unavailable[method] = []
+                    unavailable[method].append(target_path)
+                    os.chdir(orig_path)
+                    # Returning here assumes that if the first file
+                    # isn't found, none of the others will be. Don't
+                    # waste time timing out on every requested file.
+                    return unavailable
+    os.chdir(orig_path)
+    return unavailable
+
 def hsi_single_file(file_path, mode='ls'):
 
     ''' Call hsi as a subprocess for Python and return information about
@@ -194,9 +282,12 @@ def hpss_requested_files(cla, store_specs):
 
     ''' This function interacts with the "hpss" protocol in a
     provided data store specs file to download a set of files requested
-    by the user. It calls retrieve_tar for each individual file that
-    should be fetched and then untar_file to stage individual files on
-    disk.
+    by the user. Depending on the type of archive file (zip or tar), it
+    will either pull the entire file and unzip it, or attempt to pull
+    individual files from a tar file.
+
+    It cleans up local disk after files are deemed available to remove
+    any empty subdirectories that may still be present.
 
     This function exepcts that the output directory exists and is
     writable.
@@ -314,7 +405,12 @@ def hpss_requested_files(cla, store_specs):
 
     os.chdir(orig_path)
 
-def load_config(arg):
+def load_str(arg):
+
+    ''' Load a dict string safely using YAML. Return the resulting dict.  '''
+    return yaml.load(arg, Loader=yaml.SafeLoader)
+
+def config_exists(arg):
 
     '''
     Check to ensure that the provided config file exists. If it does, load it
@@ -382,16 +478,42 @@ def main(cla):
     unavailable = {}
     for data_store in cla.data_stores:
         logging.info(f'Checking {data_store} for {cla.external_model}')
-        store_specs = known_data_info.get(data_store)
+        store_specs = known_data_info.get(data_store, {})
 
-        if store_specs is None:
+        if data_store == 'disk':
+            file_names = cla.file_names if cla.file_names else \
+                known_data_info.get('hpss', {}).get('file_names')
+            logging.debug(f'User supplied file names are: {file_names}')
+            if not file_names:
+                msg = ('No file name found. They must be provided \
+                        either on the command line or on in a config file.')
+                raise argparse.ArgumentTypeError(msg)
+            unavailable = get_requested_files(cla,
+                                              file_names=file_names,
+                                              input_locs=cla.input_file_paths,
+                                              method='disk',
+                                              )
+
+        elif not store_specs:
             msg = (f'No information is available for {data_store}.')
             raise KeyError(msg)
 
-        if store_specs['protocol'] == 'download':
-            unavailable = download_requested_files(cla, data_store, store_specs)
+        if store_specs.get('protocol') == 'download':
+            file_names = store_specs.get('file_names')
+            if not file_names:
+                msg = ('No file name found. They must be provided \
+                        either on the command line or on in a config file.')
+                raise argparse.ArgumentTypeError(msg)
 
-        if store_specs['protocol'] == 'htar':
+            input_locs = store_specs['url']
+            input_locs = input_locs if isinstance(input_locs, list) else [input_locs]
+            unavailable = get_requested_files(cla,
+                                              file_names=file_names,
+                                              input_locs=input_locs,
+                                              method='download',
+                                              )
+
+        if store_specs.get('protocol') == 'htar':
             unavailable = hpss_requested_files(cla, store_specs)
 
         if not unavailable:
@@ -423,6 +545,11 @@ def parse_args():
         help='Flag for whether analysis or forecast \
         files should be gathered',
         required=True,
+        )
+    parser.add_argument(
+        '--config',
+        help='Full path to YAML with known data information',
+        type=config_exists,
         )
     parser.add_argument(
         '--cycle_date',
@@ -465,19 +592,29 @@ def parse_args():
 
     # Optional
     parser.add_argument(
-        '--config',
-        help='Full path to YAML with known data information',
-        type=load_config,
-        )
-    parser.add_argument(
         '--debug',
         action='store_true',
         help='Print debug messages',
         )
     parser.add_argument(
+        '--file_names',
+        help='Command-line user config options in YAML-formatted \
+        string to indicate file names on disk that are not \
+        consistent with the hpss archive, which are used when \
+        this flag isn\'t used.',
+        type=load_str,
+        )
+    parser.add_argument(
         '--file_type',
         choices=('grib2', 'nemsio', 'netcdf'),
         help='External model file format',
+        )
+    parser.add_argument(
+        '--input_file_paths',
+        help='Python templates known data input path. File names are ' \
+        'used from file provided by --config file. One path is needed ' \
+        'for each type of file requested.',
+        nargs='*',
         )
     return parser.parse_args()
 
@@ -486,4 +623,12 @@ if __name__ == '__main__':
     CLA = parse_args()
     CLA.output_path = path_exists(CLA.output_path)
     CLA.fcst_hrs = fhr_list(CLA.fcst_hrs)
+
+    if 'disk' in CLA.data_stores:
+        # Make sure a path was provided.
+        if not CLA.input_file_paths:
+            msg = ('You must provide an input_file_path when choosing ' \
+                   ' disk as a data store!')
+            raise argparse.ArgumentTypeError(msg)
+
     main(CLA)

--- a/ush/retrieve_data.py
+++ b/ush/retrieve_data.py
@@ -1,0 +1,124 @@
+'''
+Script is meant to use a YAML file to retrive data from a variety of
+sources, including known locations on disk, URLs, and HPSS (from
+supported NOAA platforms only).
+'''
+
+import argparse
+
+import yaml
+
+def load_config(arg):
+
+    '''
+    Check to ensure that the provided config file exists. If it does, load it
+    with YAML's safe loader and return the resulting dict.
+    '''
+
+    # Check for existence of file
+    if not os.path.exists(arg):
+        msg = f'{arg} does not exist!'
+        raise argparse.ArgumentTypeError(msg)
+
+    return yaml.safe_load(arg)
+
+def fill_template(template_str, cdate, fcst_hr):
+
+
+def download_file(target_path, url):
+
+    '''
+    Download a file from a url source, and place it in a target location
+    on disk.
+
+    Arguments:
+      target_path  full path to a location on disk where file will be
+                   stored
+      url          url to file to be downloaded
+
+    Return:
+      None
+    '''
+
+    with requests.get(url, stream=True) as r:
+        with open(target_path, 'wb') as f:
+            shutil.copyfileobj(r.raw, f)
+
+def main(cla):
+    '''
+    Uses known location information to try the known locations and file
+    paths in priority order.
+    '''
+
+    known_data_info = cla.config.get(cla.external_model)
+    if known_data_info is None:
+        msg = (f'No data stores have been defined for',
+               f'{cla.external_model}!')
+        raise KeyError(msg)
+
+    for data_store in cla.data_stores:
+        print(f'Checking {data_store} for {cla.external_model}')
+        store_specs = known_data_info.get(data_store)
+
+        if store_specs is None:
+            msg = (f'No information is available for {data_store}.')
+            raise KeyError(msg)
+
+        if store_specs == 'download':
+            base_urls = store_specs['url']
+            base_urls = base_urls if isinstance(base_urls, list) else [base_urls]
+
+            file_names = store_specs.get('file_names', {})
+            if cla.file_type is not None:
+                file_names = file_names[cla.file_type]
+            file_names = file_names[cla.anl_or_fcst]
+
+            for base_url in base_urls:
+                for file_name in file_names:
+                    url = fill_template(os.path.join(base_url, file_name),
+                                        cla.cdate,
+                                        fcst_hr)
+                    target_path = fill_template(os.path.join(cla.output,
+                                                             file_name,
+                                                             ),
+                                                cla.cdate,
+                                                fcst_hr)
+
+                    download_file(
+                        target_path=target_path
+                        url=url
+                        )
+
+def parse_args():
+
+    '''
+    Function maintains the arguments accepted by this script. Please see
+    Python's argparse documenation for more information about settings of each
+    argument.
+    '''
+
+    parser = argparse.ArgumentParser(
+        description='Retrieve data from various sources.',
+    )
+
+    help_msg = 'Full path to YAML with known data information'
+    parser.add_argument('-c', '--config',
+                        help=help_msg,
+                        type=load_config,
+                        )
+    parser.add_argument('-e', '--external_model',
+                        choices=('FV3GFS', 'GSMGFS', 'HRRR', 'NAM', 'RAP'),
+                        help='External model label',
+                        )
+    parser.add_argument('-d', '--data_stores',
+                        choices=('hpss', 'nomads', 'aws'),
+                        help='List of priority data_stores. Tries first \
+                        list item first.',
+                        nargs='*',
+                        )
+    return parser.parse_args()
+
+if __name__ == '__main__':
+
+    cla = parse_args()
+    main(cla)

--- a/ush/retrieve_data.py
+++ b/ush/retrieve_data.py
@@ -5,25 +5,13 @@ supported NOAA platforms only).
 '''
 
 import argparse
+import datetime as dt
+import os
+import shutil
+import subprocess
 
+import requests
 import yaml
-
-def load_config(arg):
-
-    '''
-    Check to ensure that the provided config file exists. If it does, load it
-    with YAML's safe loader and return the resulting dict.
-    '''
-
-    # Check for existence of file
-    if not os.path.exists(arg):
-        msg = f'{arg} does not exist!'
-        raise argparse.ArgumentTypeError(msg)
-
-    return yaml.safe_load(arg)
-
-def fill_template(template_str, cdate, fcst_hr):
-
 
 def download_file(target_path, url):
 
@@ -37,12 +25,222 @@ def download_file(target_path, url):
       url          url to file to be downloaded
 
     Return:
-      None
+      boolean value reflecting state of download.
     '''
 
-    with requests.get(url, stream=True) as r:
-        with open(target_path, 'wb') as f:
-            shutil.copyfileobj(r.raw, f)
+    print(f'Trying to download file: {url} to {target_path}')
+
+    with requests.get(url, stream=True) as req:
+        if req.status_code != 200:
+            print(f'INFO: {url} cannot be reached!')
+            return False
+        with open(target_path, 'wb') as target:
+            shutil.copyfileobj(req.raw, target)
+
+    return True
+
+def download_requested_files(cla, store_specs):
+
+    ''' This function interacts with the "download" protocol in a
+    provided data store specs file to download a set of files requested
+    by the user. It calls download_file for each individual file that
+    should be downloaded. '''
+
+    base_urls = store_specs['url']
+    base_urls = base_urls if isinstance(base_urls, list) else [base_urls]
+
+    file_names = store_specs.get('file_names', {})
+    if cla.file_type is not None:
+        file_names = file_names[cla.file_type]
+    file_names = file_names[cla.anl_or_fcst]
+
+    unavialable = {}
+    for base_url in base_urls:
+        for fcst_hr in cla.fcst_hrs:
+            for file_name in file_names:
+                url = os.path.join(base_url, file_name)
+                url = fill_template(url, cla.cycle_date, fcst_hr)
+                target_path = os.path.join(cla.output_path, file_name)
+                target_path = fill_template(target_path,
+                                            cla.cycle_date, fcst_hr)
+                downloaded = download_file(
+                    target_path=target_path,
+                    url=url,
+                    )
+                if not downloaded:
+                    unavailable[fcst_hr] = target_path
+    return unavailable
+
+def fhr_list(args):
+
+    '''
+    Given an argparse list argument, return the sequence of forecast hours to
+    process.
+
+    The length of the list will determine what forecast hours are returned:
+
+      Length = 1:   A single fhr is to be processed
+      Length = 2:   A sequence of start, stop with increment 1
+      Length = 3:   A sequence of start, stop, increment
+      Length > 3:   List as is
+
+    argparse should provide a list of at least one item (nargs='+').
+
+    Must ensure that the list contains integers.
+    '''
+
+    args = args if isinstance(args, list) else [args]
+    arg_len = len(args)
+    if arg_len in (2, 3):
+        args[1] += 1
+        return list(range(*args))
+
+    return args
+
+def fill_template(template_str, cycle_date, fcst_hr=0):
+
+    ''' Fill in the provided template string with date time information,
+    and return the resulting string.
+
+    Arguments:
+      template_str    a string containing Python templates
+      cycle_date      a datetime object that will be used to fill in
+                      date and time information
+      fcst_hr         an integer forecast hour. string formatting should
+                      be included in the template_str
+
+    Rerturn:
+      filled template string
+    '''
+    return template_str.format(
+        fcst_hr=fcst_hr,
+        dd=cycle_date.strftime('%d'),
+        hh=cycle_date.strftime('%H'),
+        mm=cycle_date.strftime('%m'),
+        jjj=cycle_date.strftime('%j'),
+        yyyy=cycle_date.strftime('%Y'),
+        yyyymm=cycle_date.strftime('%Y%m'),
+        yyyymmdd=cycle_date.strftime('%Y%m%d'),
+        yyyymmddhh=cycle_date.strftime('%Y%m%d%H'),
+        )
+
+def htar_requested_files(cla, store_specs):
+
+    ''' This function interacts with the "hpss" protocol in a
+    provided data store specs file to download a set of files requested
+    by the user. It calls retrieve_tar for each individual file that
+    should be fetched and then untar_file to stage individual files on
+    disk. '''
+
+    archive_paths = store_specs['archive_path']
+    archive_paths = archive_paths if isinstance(archive_paths, list) \
+        else [archive_paths]
+
+    # Could be a list of lists
+    archive_file_names = store_specs.get('archive_file_names', {})
+    if cla.file_type is not None:
+        archive_file_names = archive_file_names[cla.file_type]
+    archive_file_names = archive_file_names[cla.anl_or_fcst]
+
+    unavailable = {}
+    existing_archive = None
+
+    # Narrow down which HPSS files are available for this date
+    for archive_path, archive_file_names in zip(archive_paths, archive_file_names):
+        if not isinstance(archive_file_names, list):
+            archive_file_names = [archive_file_names]
+
+        # Only test the first item in the list, it will tell us if this
+        # set exists at this date.
+        file_path = os.path.join(archive_path, archive_file_names[0])
+        file_path = fill_template(file_path, cla.cycle_date)
+
+        cmd = f'hsi ls {file_path}'
+        try:
+            output = subprocess.run(cmd,
+                                    capture_output=True,
+                                    check=True,
+                                    shell=True,
+                                    )
+        except subprocess.CalledProcessError as excep:
+            print(f'{file_path} is not available!')
+        else:
+            if output.returncode == 0:
+                existing_archive = file_path
+                print(f'Found HPSS file: {file_path}')
+                break
+
+    if not existing_archive:
+        print(f'No archive files were found!')
+        return unavailable
+
+    # Use the found archive file path to get the necessary files
+    file_names = store_specs.get('file_names', {})
+    if cla.file_type is not None:
+        file_names = file_names[cla.file_type]
+    file_names = file_names[cla.anl_or_fcst]
+
+    archive_internal_dirs = store_specs.get('archive_internal_dir', [''])
+
+    output_path = fill_template(cla.output_path, cla.cycle_date)
+    print(f'Will place files in {os.path.abspath(output_path)}')
+    orig_path = os.getcwd()
+    os.chdir(output_path)
+
+    files_exist = False
+    source_paths = []
+    for archive_internal_dir in archive_internal_dirs:
+        for fcst_hr in cla.fcst_hrs:
+            for file_name in file_names:
+                source_path = os.path.join(archive_internal_dir, file_name)
+                source_paths.append(fill_template(source_path,
+                    cla.cycle_date, fcst_hr))
+        cmd = f'htar -xvf {existing_archive} {" ".join(source_paths)}'
+        print(f'Running command \n {cmd}')
+        output = subprocess.run(cmd,
+                                capture_output=True,
+                                check=True,
+                                shell=True,
+                                )
+        if output.returncode == 0:
+            break
+    os.chdir(orig_path)
+
+def load_config(arg):
+
+    '''
+    Check to ensure that the provided config file exists. If it does, load it
+    with YAML's safe loader and return the resulting dict.
+    '''
+
+    # Check for existence of file
+    if not os.path.exists(arg):
+        msg = f'{arg} does not exist!'
+        raise argparse.ArgumentTypeError(msg)
+
+    with open(arg, 'r') as config_path:
+        cfg = yaml.load(config_path, Loader=yaml.SafeLoader)
+    return cfg
+
+def path_exists(arg):
+
+    ''' Check whether the supplied path exists and is writeable '''
+
+    if not os.path.exists(arg):
+        msg = f'{arg} does not exist!'
+        raise argparse.ArgumentTypeError(msg)
+
+    if not os.access(arg, os.X_OK|os.W_OK):
+        print(f'ERROR: {arg} is not writeable!')
+        raise argparse.ArgumentTypeError(msg)
+
+    return arg
+
+def to_datetime(arg):
+    ''' Return a datetime object give a string like YYYYMMDDHH.
+    '''
+
+    return dt.datetime.strptime(arg, '%Y%m%d%H')
 
 def main(cla):
     '''
@@ -50,12 +248,13 @@ def main(cla):
     paths in priority order.
     '''
 
-    known_data_info = cla.config.get(cla.external_model)
+    known_data_info =  cla.config.get(cla.external_model)
     if known_data_info is None:
-        msg = (f'No data stores have been defined for',
+        msg = ('No data stores have been defined for',
                f'{cla.external_model}!')
         raise KeyError(msg)
 
+    unavailable = {}
     for data_store in cla.data_stores:
         print(f'Checking {data_store} for {cla.external_model}')
         store_specs = known_data_info.get(data_store)
@@ -64,30 +263,15 @@ def main(cla):
             msg = (f'No information is available for {data_store}.')
             raise KeyError(msg)
 
-        if store_specs == 'download':
-            base_urls = store_specs['url']
-            base_urls = base_urls if isinstance(base_urls, list) else [base_urls]
+        if store_specs['protocol'] == 'download':
+            unavailable = download_requested_files(cla, store_specs)
 
-            file_names = store_specs.get('file_names', {})
-            if cla.file_type is not None:
-                file_names = file_names[cla.file_type]
-            file_names = file_names[cla.anl_or_fcst]
+        if store_specs['protocol'] == 'htar':
+            unavailable = htar_requested_files(cla, store_specs)
 
-            for base_url in base_urls:
-                for file_name in file_names:
-                    url = fill_template(os.path.join(base_url, file_name),
-                                        cla.cdate,
-                                        fcst_hr)
-                    target_path = fill_template(os.path.join(cla.output,
-                                                             file_name,
-                                                             ),
-                                                cla.cdate,
-                                                fcst_hr)
-
-                    download_file(
-                        target_path=target_path
-                        url=url
-                        )
+        if not unavailable:
+            # All files are found. Stop looking!
+            break
 
 def parse_args():
 
@@ -101,24 +285,67 @@ def parse_args():
         description='Retrieve data from various sources.',
     )
 
-    help_msg = 'Full path to YAML with known data information'
-    parser.add_argument('-c', '--config',
-                        help=help_msg,
-                        type=load_config,
-                        )
-    parser.add_argument('-e', '--external_model',
-                        choices=('FV3GFS', 'GSMGFS', 'HRRR', 'NAM', 'RAP'),
-                        help='External model label',
-                        )
-    parser.add_argument('-d', '--data_stores',
-                        choices=('hpss', 'nomads', 'aws'),
-                        help='List of priority data_stores. Tries first \
-                        list item first.',
-                        nargs='*',
-                        )
+    # Required
+    parser.add_argument(
+        '--anl_or_fcst',
+        choices=('anl', 'fcst'),
+        help='Flag for whether analysis or forecast \
+        files should be gathered',
+        required=True,
+        )
+    parser.add_argument(
+        '--cycle_date',
+        help='Cycle date of the data to be retrieved in YYYYMMDDHH \
+        format.',
+        required=True,
+        type=to_datetime,
+        )
+    parser.add_argument(
+        '--data_stores',
+        help='List of priority data_stores. Tries first list item \
+        first. Choices: hpss, nomads, aws, disk',
+        nargs='*',
+        required=True,
+        )
+    parser.add_argument(
+        '--external_model',
+        choices=('FV3GFS', 'GSMGFS', 'HRRR', 'NAM', 'RAP'),
+        help='External model label',
+        required=True,
+        )
+    parser.add_argument(
+        '--fcst_hrs',
+        help='A list describing forecast hours.  If one argument, \
+        one fhr will be processed.  If 2 or 3 arguments, a sequence \
+        of forecast hours [start, stop, [increment]] will be \
+        processed.  If more than 3 arguments, the list is processed \
+        as-is.',
+        nargs='+',
+        required=True,
+        type=int,
+        )
+    parser.add_argument(
+        '--output_path',
+        help='Path to a location on disk. Path is expected to exist.',
+        required=True,
+        )
+
+    # Optional
+    parser.add_argument(
+        '--config',
+        help='Full path to YAML with known data information',
+        type=load_config,
+        )
+    parser.add_argument(
+        '--file_type',
+        choices=('grib2', 'nemsio', 'netcdf'),
+        help='External model file format',
+        )
     return parser.parse_args()
 
 if __name__ == '__main__':
 
-    cla = parse_args()
-    main(cla)
+    CLA = parse_args()
+    CLA.output_path = path_exists(CLA.output_path)
+    CLA.fcst_hrs = fhr_list(CLA.fcst_hrs)
+    main(CLA)

--- a/ush/templates/data_locations.yml
+++ b/ush/templates/data_locations.yml
@@ -1,0 +1,65 @@
+FV3GFS:
+  nomads:
+    protocol: wget
+    flags: '-c'
+    url: https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.{yyyymmdd}/{hh}/
+    file_names: &gfs_file_names
+      grib2:
+        anl:
+          - gfs.t{hh}z.pgrb2.0p25.f000
+        fcst:
+          - gfs.t{hh}z.pgrb2.0p25.f{fcst_hr:03d}
+      nemsio:
+        anl:
+          - gfs.t{hh}z.atmanl.nemsio
+          - gfs.t{hh}z.sfcanl.nemsio
+        fcst:
+          - gfs.t{hh}z.atmf{fcst_hr:03d}.nemsio
+          - gfs.t{hh}z.sfcf{fcst_hr:03d}.nemsio
+  hpss:
+    protocal: htar
+    flags: '-xvf'
+    path:
+      - /NCEPPROD/hpssprod/runhistory/rh{yyyy}/{yyyy}{mm}/{yyyymmdd}
+      - /NCEPDEV/emc-global/5year/emc.glopara/WCOSS_C/Q2FY19/prfv3rt3/{yyyymmddhh}
+    archive_internal_dir:
+      - ./gfs.{yyyymmdd}/{hh}
+      - ./gfs.{yyyymmdd}/{hh}/atmos
+    archive_names:
+      grib2:
+        anl:
+          - com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_pgrb2.tar
+          - gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_pgrb2.tar
+        fcst:
+          - com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_pgrb2.tar
+          - gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_pgrb2.tar
+      nemsio:
+        anl:
+          - com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsioa.tar
+          - gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsioa.tar
+        fcst:
+          - [com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsioa.tar, com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsiob.tar]
+          - [gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsioa.tar, gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsiob.tar]
+      netcdf:
+        anl:
+          - com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nca.tar
+          - gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nca.tar
+        fcst:
+          - [com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nca.tar, com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_ncb.tar]
+          - [gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nca.tar, gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_ncb.tar]
+    file_names:
+      <<: *gfs_file_names
+  aws:
+    protocol: wget
+    flags: '-c'
+    url: https://noaa-gfs-bdp-pds.s3.amazonaws.com/gfs.{yyyymmdd}/{hh}/atmos
+    file_names:
+      <<: *gfs_file_names
+
+
+
+
+
+
+
+

--- a/ush/templates/data_locations.yml
+++ b/ush/templates/data_locations.yml
@@ -1,7 +1,58 @@
+#
+# This file tracks known data store locations for data used as input to
+# the SRW App configuations.
+#
+# The contents should be organized as follows:
+#
+# Top level: A key corresponding to an external model file or
+# observation dataset accepted by the SRW App.
+#
+# 2nd level: A key corressponding to a named datastore for a given data
+# set. This could be nomads, aws, hpss, etc.
+#
+# 3rd level required:
+#
+# protocol:
+#   indication of how a set of files will be retrieved. Options:
+#   download or htar. The requirements for each protocol are described
+#   below
+#
+# file_names:
+#   Each data store will require an entry that describes the names of
+#   files to be extracted from the data store. These entries are
+#   expected as lists to indicate when multiple files should be
+#   retrieved.  anl and fcst subsections indicate the naming convention
+#   for that type of file. Both are required for external models ICS and
+#   LBCS. Each file name may (and likely should) include templates.
+#
+#   If the SRW App accepts different file formats,
+#   as it does for FV3GFS, an intermediary level indicating the value
+#   associate with a FV3GFS_FILE_FMT_* variable.
+#
+# 3rd level optional:
+#
+#  for download protocol:
+#     url: required. the URL to the location of the data file. May include
+#          templates.
+#
+#  for htar protocol:
+#     archive_path: a list of paths to the potential location of the
+#                   archive file on HPSS. since there may be multiple
+#                   options for a given external model file, the list
+#                   will be searched in order listed below.
+#     archive_file_names: the name of the archive file. this could
+#                   differ for each archive_path option, so one entry is
+#                   needed (even if it's identical) for each entry of
+#                   archive_path provided
+#     archive_internal_dir: (optional) a path to data files stored
+#                   inside a given archive file
+#
+#
+#
 FV3GFS:
   nomads:
     protocol: download
-    url: https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.{yyyymmdd}/{hh}/
+    url: https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.{yyyymmdd}/{hh}/atmos
     file_names: &gfs_file_names
       grib2:
         anl:
@@ -16,49 +67,39 @@ FV3GFS:
           - gfs.t{hh}z.atmf{fcst_hr:03d}.nemsio
           - gfs.t{hh}z.sfcf{fcst_hr:03d}.nemsio
   hpss:
-    protocal: htar
-    flags: '-xvf'
-    path:
-      - /NCEPPROD/hpssprod/runhistory/rh{yyyy}/{yyyy}{mm}/{yyyymmdd}
-      - /NCEPDEV/emc-global/5year/emc.glopara/WCOSS_C/Q2FY19/prfv3rt3/{yyyymmddhh}
+    protocol: htar
+    archive_path:
+      - /NCEPPROD/hpssprod/runhistory/rh{yyyy}/{yyyymm}/{yyyymmdd}
+      - /NCEPPROD/hpssprod/runhistory/rh{yyyy}/{yyyymm}/{yyyymmdd}
     archive_internal_dir:
       - ./gfs.{yyyymmdd}/{hh}
       - ./gfs.{yyyymmdd}/{hh}/atmos
-    archive_names:
+    archive_file_names:
       grib2:
         anl:
-          - com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_pgrb2.tar
           - gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_pgrb2.tar
+          - com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_pgrb2.tar
         fcst:
-          - com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_pgrb2.tar
           - gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_pgrb2.tar
+          - com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_pgrb2.tar
       nemsio:
         anl:
-          - com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsioa.tar
           - gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsioa.tar
+          - com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsioa.tar
         fcst:
-          - [com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsioa.tar, com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsiob.tar]
-          - [gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsioa.tar, gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsiob.tar]
+          - ['gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsioa.tar', 'gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsiob.tar']
+          - ['com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsioa.tar', 'com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nemsiob.tar']
       netcdf:
         anl:
-          - com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nca.tar
           - gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nca.tar
+          - com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nca.tar
         fcst:
-          - [com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nca.tar, com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_ncb.tar]
-          - [gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nca.tar, gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_ncb.tar]
+          - ['gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nca.tar', 'gpfs_dell1_nco_ops_com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_ncb.tar']
+          - ['com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_nca.tar', 'com_gfs_prod_gfs.{yyyymmdd}_{hh}.gfs_ncb.tar']
     file_names:
       <<: *gfs_file_names
   aws:
     protocol: download
-    flags: '-c'
     url: https://noaa-gfs-bdp-pds.s3.amazonaws.com/gfs.{yyyymmdd}/{hh}/atmos
     file_names:
       <<: *gfs_file_names
-
-
-
-
-
-
-
-

--- a/ush/templates/data_locations.yml
+++ b/ush/templates/data_locations.yml
@@ -1,4 +1,3 @@
-#
 # This file tracks known data store locations for data used as input to
 # the SRW App configuations.
 #
@@ -103,3 +102,88 @@ FV3GFS:
     url: https://noaa-gfs-bdp-pds.s3.amazonaws.com/gfs.{yyyymmdd}/{hh}/atmos
     file_names:
       <<: *gfs_file_names
+
+RAP:
+  hpss:
+    protocol: htar
+    archive_format: tar
+    archive_path:
+      - /NCEPPROD/hpssprod/runhistory/rh{yyyy}/{yyyymm}/{yyyymmdd}
+    archive_file_names:
+      # RAP forecasts are binned into 6 hour tar files.
+      - com_rap_prod_rap.{yyyymmdd}{bin6}.wrf.tar
+    file_names: &rap_file_names
+      anl:
+        - rap.t{hh}z.wrfnatf{fcst_hr:02d}.grib2
+      fcst:
+        - rap.t{hh}z.wrfnatf{fcst_hr:02d}.grib2
+  aws:
+    protocol: download
+    url: https://noaa-rap-pds.s3.amazonaws.com/rap.{yyyymmdd}
+    file_names:
+      <<: *rap_file_names
+
+RAPx:
+  hpss:
+    protocol: htar
+    archive_format: zip
+    archive_path:
+      - /BMC/fdr/Permanent/{yyyy}/{mm}/{dd}/data/fsl/rap/full/wrfnat
+    archive_file_names:
+      # RAPx bins two cycles togehter, and named by the lower even value
+      # of the cycle hour.
+      - '{yyyymmdd}{hh_even}00.zip'
+    file_names:
+      anl:
+        - '{yy}{jjj}{hh}00{fcst_hr:02d}00'
+      fcst:
+        - '{yy}{jjj}{hh}00{fcst_hr:02d}00'
+
+HRRR:
+  hpss:
+    protocol: htar
+    archive_format: tar
+    archive_path:
+      - /NCEPPROD/hpssprod/runhistory/rh{yyyy}/{yyyymm}/{yyyymmdd}
+    archive_file_names:
+      # HRRR forecasts are binned into 6 hour tar files.
+      - com_hrrr_prod_hrrr.{yyyymmdd}_conus{bin6}.wrfnatdng.tar
+    file_names: &hrrr_file_names
+      anl:
+        - hrrr.t{hh}z.wrfnatf{fcst_hr:02d}.grib2
+      fcst:
+        - hrrr.t{hh}z.wrfnatf{fcst_hr:02d}.grib2
+  aws:
+    protocol: download
+    url: https://noaa-hrrr-bdp-pds.s3.amazonaws.com/hrrr.{yyyymmdd}/conus/
+    file_names:
+      <<: *hrrr_file_names
+
+HRRRx:
+  hpss:
+    protocol: htar
+    archive_format: zip
+    archive_path:
+      - /BMC/fdr/Permanent/{yyyy}/{mm}/{dd}/data/fsl/hrrr/conus/wrfnat
+    archive_file_names:
+      - '{yyyymmddhh}00.zip'
+    file_names:
+      anl:
+        - '{yy}{jjj}{hh}00{fcst_hr:02d}00'
+      fcst:
+        - '{yy}{jjj}{hh}00{fcst_hr:02d}00'
+
+NAM:
+  hpss:
+    protocol: htar
+    archive_format: tar
+    archive_path:
+      - /NCEPPROD/hpssprod/runhistory/rh{yyyy}/{yyyymm}/{yyyymmdd}
+    archive_file_names:
+      - com_nam_prod_nam.{yyyymmddhh}.bgrid.tar
+    file_names:
+      anl:
+        - nam.t{hh}z.bgrdsf{fcst_hr:03d}.tm00
+      fcst:
+        - nam.t{hh}z.bgrdsf{fcst_hr:03d}
+

--- a/ush/templates/data_locations.yml
+++ b/ush/templates/data_locations.yml
@@ -1,7 +1,6 @@
 FV3GFS:
   nomads:
-    protocol: wget
-    flags: '-c'
+    protocol: download
     url: https://nomads.ncep.noaa.gov/pub/data/nccf/com/gfs/prod/gfs.{yyyymmdd}/{hh}/
     file_names: &gfs_file_names
       grib2:
@@ -50,7 +49,7 @@ FV3GFS:
     file_names:
       <<: *gfs_file_names
   aws:
-    protocol: wget
+    protocol: download
     flags: '-c'
     url: https://noaa-gfs-bdp-pds.s3.amazonaws.com/gfs.{yyyymmdd}/{hh}/atmos
     file_names:

--- a/ush/templates/data_locations.yml
+++ b/ush/templates/data_locations.yml
@@ -109,6 +109,8 @@ RAP:
     archive_format: tar
     archive_path:
       - /NCEPPROD/hpssprod/runhistory/rh{yyyy}/{yyyymm}/{yyyymmdd}
+    archive_internal_dir:
+      - ./
     archive_file_names:
       # RAP forecasts are binned into 6 hour tar files.
       - com_rap_prod_rap.{yyyymmdd}{bin6}.wrf.tar
@@ -145,6 +147,8 @@ HRRR:
     archive_format: tar
     archive_path:
       - /NCEPPROD/hpssprod/runhistory/rh{yyyy}/{yyyymm}/{yyyymmdd}
+    archive_internal_dir:
+      - ./
     archive_file_names:
       # HRRR forecasts are binned into 6 hour tar files.
       - com_hrrr_prod_hrrr.{yyyymmdd}_conus{bin6}.wrfnatdng.tar


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This tool is a stand alone script that can be used to grab external model files from a variety of sources including the internet, disk, and HPSS. The known locations for BDP AWS, HPSS, and NOMADS have been added here for demo purposes. It will also accept command line options to support user-defined disk locations with the caveat that file names provided on the command line must match the formatting necessary in the config file. A list of options for data_stores can be provided, and each will be checked until the required files are found. The list of known locations could easily be extended to add observation file locations for verification and data assimilation (future) purposes.

This tool has not yet been hooked into the workflow. I would like to receive feedback on the tool itself before moving forward with replacing existing functionality in the run scripts. 

I envision that this tool would be called from a job script, so am unsure whether it makes sense to store it under ush or scripts.

Example of pulling grib2 files from hpss or aws for FV3GFS:
```
    python retrieve_data.py 
        --anl_or_fcst fcst 
        --cycle_date 2022010212 
        --data_stores hpss aws 
        --external_model FV3GFS 
        --file_type grib2
        --fcst_hrs 0 3 
        --output_path test_output_loc 
        --config ./templates/data_locations.yml 
        --debug 
        --file_type grib2
```
Similarly, if you wanted to check disk first:
```
    files=settings="
        'grib2':
           'fcst': gfs.t{hh}z.pgrb2.0p25.f{fcst_hr:03d}
    "
    python retrieve_data.py 
        --anl_or_fcst fcst 
        --cycle_date 2022010212 
        --data_stores hpss aws 
        --external_model FV3GFS 
        --file_type grib2
        --fcst_hrs 0 3 
        --output_path test_output_loc 
        --config ./templates/data_locations.yml 
        --debug 
        --file_type grib2
        --input_file_paths /scratch1/NCEPDEV/rstprod/com/gfs/prod/gfs.{yyyymmdd}/{hh}/atmos
        --file_name ${files}
```


## TESTS CONDUCTED: 
I've run many tests locally to try out pulling from various data sources. NOMADS never seems to work (nor does it when I run from the existing regional_workflow scripts).

## DEPENDENCIES:
Requires the packages from existing regional_workflow conda packages.

## DOCUMENTATION:
I'm not sure where it makes sense to document this tool, or if it does, since it replaces existing docs.
